### PR TITLE
Automatic batch_size and epochs setting, train_speed option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -116,7 +116,8 @@ metrics = m.fit(df, validate_each_epoch=True, valid_p=0.2)
 
 ## Reproducibility
 The variability of results comes from SGD finding different optima on different runs.
-The majority of the randomness comes from the random initialization of weights, different learning rates and different shuffling of the dataloader.
+The majority of the randomness comes from the random initialization of weights, 
+different learning rates and different shuffling of the dataloader.
 We can control the random number generator by setting it's seed:
 ```python
 from neuralprophet import set_random_seed 

--- a/docs/hyperparameter-selection.md
+++ b/docs/hyperparameter-selection.md
@@ -23,8 +23,10 @@ are as follows.
 | `d_hidden`   | None |
 | `ar_sparsity`   | None |
 | `learning_rate`   | None |
-| `epochs`   | 40 |
+| `epochs`   | None |
+| `batch_size`   | None |
 | `loss_func`   | Huber |
+| `train_speed`   | None |
 | `normalize_y`   | auto |
 | `impute_missing`   | True |
 | `log_level`   | None |
@@ -45,13 +47,17 @@ on either domain expertise or an empirical analysis.
 
 ## Model Training Related Parameters
 NeuralProphet is fit with stochastic gradient descent - more precisely, with an AdamW optimizer and a One-Cycle policy. 
-If the parameter `learning_rate` is not specified, a learning rate range test is conducted to determin the optimal learning rate. 
+If the parameter `learning_rate` is not specified, a learning rate range test is conducted to determine the optimal learning rate. 
 The `epochs` and the `loss_func` are two other parameters that directly affect the model training process. 
-If, by looking at the live loss plot, the model looks like it's underfitting, the number of `epochs`  or the `learning_rate` can be increased. 
-On the other hand, if the model looks like it is overfitting to the training data, the number of `epochs`  or the `learning_rate` can be reduced. 
-The default for `epochs` is 40, which could likely be reduced for most datasets. 
-The default loss function is Huber loss, which is considered to be robust to outliers. 
-However, you can select from `Huber`, `MAE` and `MSE` or any PyTorch loss function. 
+If not defined, both are automatically set based on the dataset size. 
+They are set in a manner that controls the total number training steps to be around 1000 to 4000.
+
+If it looks like the model is overfitting to the training data (the live loss plot can be useful hereby), 
+you can reduce `epochs`  and `learning_rate`, and potentially increase the `batch_size`. 
+If it is underfitting, the number of `epochs` and `learning_rate` can be increased and the `batch_size` potentially decreased. 
+
+The default loss function is the 'Huber' loss, which is considered to be robust to outliers. 
+However, you are free to choose the standard `MSE` or any other PyTorch `torch.nn.modules.loss` loss function. 
 
 ## Increasing Depth of the Model
 `num_hidden_layers` defines the number of hidden layers of the FFNNs used in the overall model. This includes the

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -152,9 +152,9 @@ class Train:
 
     def apply_train_speed(self):
         if self.train_speed is not None and not math.isclose(self.train_speed, 0):
-            self.batch_size *= 2 ** self.train_speed
-            self.learning_rate *= 2 ** self.train_speed
-            self.epochs *= 2 ** -self.train_speed
+            self.batch_size = int(self.batch_size * 2 ** self.train_speed)
+            self.learning_rate = self.learning_rate * 2 ** self.train_speed
+            self.epochs = int(self.epochs * 2 ** -self.train_speed)
 
 
 @dataclass

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -128,8 +128,21 @@ class Train:
         else:
             raise NotImplementedError("Loss function {} not found".format(self.loss_func))
 
-    def set_auto_batch_epoch(self, n_data):
-        pass
+    def set_auto_batch_epoch(
+        self,
+        n_data: int,
+        min_batch: int = 1,
+        max_batch: int = 128,
+    ):
+        assert n_data >= 1
+        log_data = int(np.log10(n_data))
+        if self.batch_size is None:
+            log2_batch = 2 * log_data - 1
+            self.batch_size = 2 ** log2_batch
+            self.batch_size = min(max_batch, max(min_batch, self.batch_size))
+        if self.epochs is None:
+            datamult = 1000.0 / float(n_data)
+            self.epochs = datamult * (2 ** (3 + log_data))
 
 
 @dataclass

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -133,6 +133,8 @@ class Train:
         n_data: int,
         min_batch: int = 1,
         max_batch: int = 128,
+        min_epoch: int = 5,
+        max_epoch: int = 1000,
     ):
         assert n_data >= 1
         log_data = int(np.log10(n_data))
@@ -140,9 +142,12 @@ class Train:
             log2_batch = 2 * log_data - 1
             self.batch_size = 2 ** log2_batch
             self.batch_size = min(max_batch, max(min_batch, self.batch_size))
+            log.info("Batch size auto-set to {}".format(self.batch_size))
         if self.epochs is None:
             datamult = 1000.0 / float(n_data)
             self.epochs = datamult * (2 ** (3 + log_data))
+            self.epochs = min(max_epoch, max(min_epoch, self.epochs))
+            log.info("Epochs auto-set to {}".format(self.epochs))
 
 
 @dataclass

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -104,6 +104,7 @@ class Train:
     epochs: (int, None)
     batch_size: (int, None)
     loss_func: (str, torch.nn.modules.loss._Loss)
+    train_speed: (int, float, None)
     ar_sparsity: (float, None)
     reg_delay_pct: float = 0.5
     lambda_delay: int = field(init=False)
@@ -148,6 +149,12 @@ class Train:
             self.epochs = int(datamult * (2 ** (3 + log_data)))
             self.epochs = min(max_epoch, max(min_epoch, self.epochs))
             log.info("Auto-set epochs to {}".format(self.epochs))
+
+    def apply_train_speed(self):
+        if self.train_speed is not None and not math.isclose(self.train_speed, 0):
+            self.batch_size *= 2 ** self.train_speed
+            self.learning_rate *= 2 ** self.train_speed
+            self.epochs *= 2 ** -self.train_speed
 
 
 @dataclass

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -100,11 +100,11 @@ class AllSeason:
 
 @dataclass
 class Train:
-    learning_rate: float
-    epochs: int
-    batch_size: int
+    learning_rate: (float, None)
+    epochs: (int, None)
+    batch_size: (int, None)
     loss_func: (str, torch.nn.modules.loss._Loss)
-    ar_sparsity: float
+    ar_sparsity: (float, None)
     reg_delay_pct: float = 0.5
     lambda_delay: int = field(init=False)
     reg_lambda_trend: float = None
@@ -142,12 +142,12 @@ class Train:
             log2_batch = 2 * log_data - 1
             self.batch_size = 2 ** log2_batch
             self.batch_size = min(max_batch, max(min_batch, self.batch_size))
-            log.info("Batch size auto-set to {}".format(self.batch_size))
+            log.info("Auto-set batch_size to {}".format(self.batch_size))
         if self.epochs is None:
             datamult = 1000.0 / float(n_data)
             self.epochs = int(datamult * (2 ** (3 + log_data)))
             self.epochs = min(max_epoch, max(min_epoch, self.epochs))
-            log.info("Epochs auto-set to {}".format(self.epochs))
+            log.info("Auto-set epochs to {}".format(self.epochs))
 
 
 @dataclass

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -145,7 +145,7 @@ class Train:
             log.info("Batch size auto-set to {}".format(self.batch_size))
         if self.epochs is None:
             datamult = 1000.0 / float(n_data)
-            self.epochs = datamult * (2 ** (3 + log_data))
+            self.epochs = int(datamult * (2 ** (3 + log_data)))
             self.epochs = min(max_epoch, max(min_epoch, self.epochs))
             log.info("Epochs auto-set to {}".format(self.epochs))
 

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -116,9 +116,9 @@ class NeuralProphet:
                 For manual values, try ~1-512.
             loss_func (str, torch.nn.modules.loss._Loss): Type of loss to use ['Huber', 'MAE', 'MSE']
             train_speed (int, float) a quick setting to speed up or slow down model fitting [-3, -2, -1, 0, 1, 2, 3]
-                potentially useful when under, overfitting, or simply in a hurry.
-                applies: epochs *= 2**-train_speed, batch_size *= 2**train_speed, learning_rate *= 2**train_speed,
-                default: None: equivalent to 0.
+                potentially useful when under-, over-fitting, or simply in a hurry.
+                applies epochs *= 2**-train_speed, batch_size *= 2**train_speed, learning_rate *= 2**train_speed,
+                default None: equivalent to 0.
 
             ## Data config
             normalize (str): Type of normalization to apply to the time series.

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -50,8 +50,8 @@ class NeuralProphet:
         d_hidden=None,
         ar_sparsity=None,
         learning_rate=None,
-        epochs=40,
-        batch_size=64,
+        epochs=None,
+        batch_size=None,
         loss_func="Huber",
         normalize="auto",
         impute_missing=True,
@@ -102,10 +102,17 @@ class NeuralProphet:
             d_hidden (int): dimension of hidden layers of the AR-Net. Ignored if num_hidden_layers == 0.
 
             ## Train Config
-            learning_rate (float): Multiplier for learning rate.
-                Try values ~0.001-10.
+            learning_rate (float): Maximum learning rate setting for 1cycle policy scheduler.
+                default: None: Automatically sets the learning_rate based on a learning rate range test.
+                For manual values, try values ~0.001-10.
             epochs (int): Number of epochs (complete iterations over dataset) to train model.
-                Try ~10-100.
+                default: None: Automatically sets the number of epochs based on dataset size.
+                    For best results also leave batch_size to None.
+                For manual values, try ~5-500.
+            batch_size (int): Number of samples per mini-batch.
+                default: None: Automatically sets the batch_size based on dataset size.
+                    For best results also leave epochs to None.
+                For manual values, try ~1-512.
             loss_func (str, torch.nn.modules.loss._Loss): Type of loss to use ['Huber', 'MAE', 'MSE']
 
             ## Data config
@@ -426,6 +433,7 @@ class NeuralProphet:
                 self.country_holidays_config["holiday_names"] = utils.get_holidays_from_country(
                     self.country_holidays_config["country"], df["ds"]
                 )
+            self.config_train.set_auto_batch_epoch(n_data=len(df))
         dataset = self._create_dataset(df, predict_mode=False)  # needs to be called after set_auto_seasonalities
         loader = DataLoader(dataset, batch_size=self.config_train.batch_size, shuffle=True)
         if not self.fitted:

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -115,9 +115,9 @@ class NeuralProphet:
                     For best results also leave epochs to None.
                 For manual values, try ~1-512.
             loss_func (str, torch.nn.modules.loss._Loss): Type of loss to use ['Huber', 'MAE', 'MSE']
-            train_speed (int) a quick setting to speed up or slow down model fitting [-3, -2, -1, 0, 1, 2, 3]
+            train_speed (int, float) a quick setting to speed up or slow down model fitting [-3, -2, -1, 0, 1, 2, 3]
                 potentially useful when under, overfitting, or simply in a hurry.
-                sets: epochs *= 2**-train_speed, batch_size *= 2**train_speed, learning_rate *= 2**train_speed,
+                applies: epochs *= 2**-train_speed, batch_size *= 2**train_speed, learning_rate *= 2**train_speed,
                 default: None: equivalent to 0.
 
             ## Data config
@@ -438,7 +438,8 @@ class NeuralProphet:
                 self.country_holidays_config["holiday_names"] = utils.get_holidays_from_country(
                     self.country_holidays_config["country"], df["ds"]
                 )
-            self.config_train.set_auto_batch_epoch(n_data=len(df))
+        self.config_train.set_auto_batch_epoch(n_data=len(df))
+        self.config_train.apply_train_speed()
         dataset = self._create_dataset(df, predict_mode=False)  # needs to be called after set_auto_seasonalities
         loader = DataLoader(dataset, batch_size=self.config_train.batch_size, shuffle=True)
         if not self.fitted:

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -53,6 +53,7 @@ class NeuralProphet:
         epochs=None,
         batch_size=None,
         loss_func="Huber",
+        train_speed=None,
         normalize="auto",
         impute_missing=True,
         log_level=None,
@@ -114,6 +115,10 @@ class NeuralProphet:
                     For best results also leave epochs to None.
                 For manual values, try ~1-512.
             loss_func (str, torch.nn.modules.loss._Loss): Type of loss to use ['Huber', 'MAE', 'MSE']
+            train_speed (int) a quick setting to speed up or slow down model fitting [-3, -2, -1, 0, 1, 2, 3]
+                potentially useful when under, overfitting, or simply in a hurry.
+                sets: epochs *= 2**-train_speed, batch_size *= 2**train_speed, learning_rate *= 2**train_speed,
+                default: None: equivalent to 0.
 
             ## Data config
             normalize (str): Type of normalization to apply to the time series.

--- a/tests/debug.py
+++ b/tests/debug.py
@@ -71,6 +71,7 @@ def debug_unit_all(plot=False):
     utests.test_impute_missing()
     utests.test_time_dataset()
     utests.test_normalize()
+    utests.test_auto_batch_epoch()
 
 
 def debug_all():
@@ -110,12 +111,12 @@ def debug_one():
     test_unit.UnitTests.plot = plot
     utests = test_unit.UnitTests()
     ##
-    # utests.test_()
+    utests.test_auto_batch_epoch()
 
 
 if __name__ == "__main__":
     # TODO: add argparse to allow for plotting with tests using command line
     # TODO: add hard performance criteria to training tests, setting seeds
     # debug_logger()
-    debug_all()
-    # debug_one()
+    # debug_all()
+    debug_one()

--- a/tests/debug.py
+++ b/tests/debug.py
@@ -112,12 +112,12 @@ def debug_one():
     test_unit.UnitTests.plot = plot
     utests = test_unit.UnitTests()
     ##
-    utests.test_train_speed()
+    # utests.test_train_speed()
 
 
 if __name__ == "__main__":
     # TODO: add argparse to allow for plotting with tests using command line
     # TODO: add hard performance criteria to training tests, setting seeds
     # debug_logger()
-    # debug_all()
-    debug_one()
+    debug_all()
+    # debug_one()

--- a/tests/debug.py
+++ b/tests/debug.py
@@ -72,6 +72,7 @@ def debug_unit_all(plot=False):
     utests.test_time_dataset()
     utests.test_normalize()
     utests.test_auto_batch_epoch()
+    utests.test_train_speed()
 
 
 def debug_all():
@@ -111,7 +112,7 @@ def debug_one():
     test_unit.UnitTests.plot = plot
     utests = test_unit.UnitTests()
     ##
-    utests.test_auto_batch_epoch()
+    utests.test_train_speed()
 
 
 if __name__ == "__main__":

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -115,13 +115,36 @@ class UnitTests(unittest.TestCase):
             df_norm = df_utils.normalize(df, data_params)
 
     def test_auto_batch_epoch(self):
-        for n_data in [1, 10, 1e2, 1e3, 1e4, 1e5, 1e6]:
+        check = {
+            "1": (1, 1000),
+            "10": (2, 1000),
+            "100": (8, 320),
+            "1000": (32, 64),
+            "10000": (128, 12),
+            "100000": (128, 5),
+        }
+        for n_data in [1, 10, int(1e2), int(1e3), int(1e4), int(1e5)]:
             c = configure.Train(
-                learning_rate=None,
-                epochs=None,
-                batch_size=None,
-                loss_func="mse",
-                ar_sparsity=None,
+                learning_rate=None, epochs=None, batch_size=None, loss_func="mse", ar_sparsity=None, train_speed=0
             )
             c.set_auto_batch_epoch(n_data)
             log.debug("n_data: {}, batch: {}, epoch: {}".format(n_data, c.batch_size, c.epochs))
+            batch, epoch = check["{}".format(n_data)]
+            assert c.batch_size == batch
+            assert c.epochs == epoch
+
+    def test_train_speed(self):
+        df = pd.read_csv(PEYTON_FILE, nrows=128)
+        train_speed = 1
+        m = NeuralProphet(
+            learning_rate=1,
+            batch_size=16,
+            epochs=2,
+            train_speed=train_speed,
+        )
+        m.fit(df, freq="D")
+        log.debug(
+            "train_speed: {}, batch: {}, epoch: {}".format(
+                train_speed, m.config_train.batch_size, m.config_train.epochs
+            )
+        )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -11,6 +11,7 @@ from neuralprophet import (
     NeuralProphet,
     df_utils,
     time_dataset,
+    configure,
 )
 
 log = logging.getLogger("nprophet.test")
@@ -112,3 +113,10 @@ class UnitTests(unittest.TestCase):
                 events_config=m.events_config,
             )
             df_norm = df_utils.normalize(df, data_params)
+
+    def test_auto_batch_epoch(self):
+        c = configure.Train(
+            learning_rate=1,
+            epochs=None,
+            batch_size=1,
+        )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -115,8 +115,13 @@ class UnitTests(unittest.TestCase):
             df_norm = df_utils.normalize(df, data_params)
 
     def test_auto_batch_epoch(self):
-        c = configure.Train(
-            learning_rate=1,
-            epochs=None,
-            batch_size=1,
-        )
+        for n_data in [1, 10, 1e2, 1e3, 1e4, 1e5, 1e6]:
+            c = configure.Train(
+                learning_rate=None,
+                epochs=None,
+                batch_size=None,
+                loss_func="mse",
+                ar_sparsity=None,
+            )
+            c.set_auto_batch_epoch(n_data)
+            log.debug("n_data: {}, batch: {}, epoch: {}".format(n_data, c.batch_size, c.epochs))


### PR DESCRIPTION
If not defined, both batch_size and epochs are automatically set based on the dataset size. 
They are set in a manner that controls the total number training steps to be around 1000 to 4000.

also new:
            train_speed (int, float) a quick setting to speed up or slow down model fitting [-3, -2, -1, 0, 1, 2, 3]
                potentially useful when under-, over-fitting, or simply in a hurry.
                applies epochs *= 2**-train_speed, batch_size *= 2**train_speed, learning_rate *= 2**train_speed,
                default None: equivalent to 0.