### PR TITLE
Allow missing values left unimputed - drop affected areas

### DIFF
--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -172,6 +172,11 @@ def check_dataframe(df, check_y=True, covariates=None, regressors=None, events=N
     if df["ds"].dt.tz is not None:
         raise ValueError("Column ds has timezone specified, which is not supported. Remove timezone.")
 
+    # FIX Issue #53: Data: fail with specific error message when data contains duplicate date entries.
+    if len(df.ds.unique()) != len(df.ds):
+        raise ValueError("Column ds has duplicate values. Please remove duplicates.")
+    # END FIX
+
     columns = []
     if check_y:
         columns.append("y")

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -92,30 +92,34 @@ def get_normalization_params(array, norm_type):
         norm_type = auto_normalization_setting(array)
     shift = 0.0
     scale = 1.0
+    # FIX Issue#52
+    # Ignore NaNs (if any) in array for normalization
+    non_nan_array = array[~np.isnan(array)]
     if norm_type == "soft":
-        lowest = np.min(array)
-        q95 = np.quantile(array, 0.95, interpolation="higher")
+        lowest = np.min(non_nan_array)
+        q95 = np.quantile(non_nan_array, 0.95, interpolation="higher")
         width = q95 - lowest
         if math.isclose(width, 0):
-            width = np.max(array) - lowest
+            width = np.max(non_nan_array) - lowest
         shift = lowest
         scale = width
     elif norm_type == "soft1":
-        lowest = np.min(array)
-        q90 = np.quantile(array, 0.9, interpolation="higher")
+        lowest = np.min(non_nan_array)
+        q90 = np.quantile(non_nan_array, 0.9, interpolation="higher")
         width = q90 - lowest
         if math.isclose(width, 0):
-            width = (np.max(array) - lowest) / 1.25
+            width = (np.max(non_nan_array) - lowest) / 1.25
         shift = lowest - 0.125 * width
         scale = 1.25 * width
     elif norm_type == "minmax":
-        shift = np.min(array)
-        scale = np.max(array) - shift
+        shift = np.min(non_nan_array)
+        scale = np.max(non_nan_array) - shift
     elif norm_type == "standardize":
-        shift = np.mean(array)
-        scale = np.std(array)
+        shift = np.mean(non_nan_array)
+        scale = np.std(non_nan_array)
     elif norm_type != "off":
         log.error("Normalization {} not defined.".format(norm_type))
+    # END FIX
     return ShiftScale(shift, scale)
 
 

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -279,13 +279,15 @@ class NeuralProphet:
             if missing_dates > 0:
                 if self.impute_missing:
                     log.info("{} missing dates added.".format(missing_dates))
-                else:
-                    raise ValueError(
-                        "{} missing dates found. Please preprocess data manually or set impute_missing to True.".format(
-                            missing_dates
-                        )
-                    )
-
+            # FIX Issue#52
+            # Comment error raising to allow missing data for autoregression flow.
+            #    else:
+            #        raise ValueError(
+            #            "{} missing dates found. Please preprocess data manually or set impute_missing to True.".format(
+            #                missing_dates
+            #            )
+            #        )
+            # END FIX
         # impute missing values
         data_columns = []
         if self.n_lags > 0:
@@ -318,10 +320,13 @@ class NeuralProphet:
                                 2 * self.impute_limit_linear + self.impute_rolling, column, remaining_na
                             )
                         )
-                else:  # fail because set to not impute missing
-                    raise ValueError(
-                        "Missing values found. " "Please preprocess data manually or set impute_missing to True."
-                    )
+                # FIX Issue#52
+                # Comment error raising to allow missing data for autoregression flow.
+                # else:  # fail because set to not impute missing
+                #    raise ValueError(
+                #        "Missing values found. " "Please preprocess data manually or set impute_missing to True."
+                #    )
+                # END FIX
         return df
 
     def _validate_column_name(self, name, events=True, seasons=True, regressors=True, covariates=True):

--- a/tests/debug.py
+++ b/tests/debug.py
@@ -84,6 +84,7 @@ def debug_unit_all(plot=False):
     utests.test_split_impute()
     utests.test_cv()
     utests.test_reg_delay()
+    utests.test_check_duplicate_ds()
 
 
 def debug_all():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -317,3 +317,25 @@ class UnitTests(unittest.TestCase):
             weight = c.get_reg_delay_weight(e, i, reg_start_pct=0.5, reg_full_pct=0.8)
             log.debug("e {}, i {}, expected w {}, got w {}".format(e, i, w, weight))
             assert weight == w
+
+    def test_check_duplicate_ds(self):
+        # Check whether a ValueError is thrown in case there
+        # are duplicate dates in the ds column of dataframe
+
+        df = pd.read_csv(PEYTON_FILE, nrows=102)[:50]
+
+        # introduce duplicates in dataframe
+        df = pd.concat([df, df[8:9]]).reset_index()
+
+        # Check if error thrown on duplicates
+        error = False
+        try:
+            m = NeuralProphet(
+                n_lags=24,
+                ar_sparsity=0.5,
+            )
+            metrics = m.fit(df, freq="D")
+        except ValueError:
+            error = True
+        finally:
+            assert error is True


### PR DESCRIPTION
Implementing a fix for Issue#52:

- Allow missing values for Autoregression when opting not to impute
- After creating time dataset, remove the windows that have ANY missing values