### PR TITLE
Future regressor positivity constraint - Issue #189

### DIFF
--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -331,6 +331,7 @@ class Regressor:
     reg_lambda: float
     normalize: str
     mode: str
+    constraint: str
 
 
 @dataclass


### PR DESCRIPTION
**Status quo:**
Future regressors are currently not constrained or sanity checked to fulfil any criteria.
However, this functionality is requested by #189.

This pr implements the data positivity constraint that was proposed by @ourownstory in the discussion:
"Nevertheless, this could be avoided by throwing a warning/error if a user sets a positivity constraint and then provides negative training values." [Discussion](https://github.com/ourownstory/neural_prophet/discussions/141#discussioncomment-169682)

**Changes:**
- Extended the `add_future_regressor` function with the attribute `constraint` which can take the values `None (default)`  or `positive`
- Extended the Regressor class with a `constraint` attribute
- Extended the `__handle_missing_data` function to check for negative values and raise a `ValueError` in case.

**Open questions:**
- Is raising a `ValueError` the expected behaviour? I would argue yes, as with this implementation the user would explicitly state that he expects only positive values to be in the df and therefore should be informed.
- Is `__handle_missing_data` the appropriate place to check the constraint? It seems to be the most straight forward as the regressors are anyways checked in the function but one could argue that it is not really related to missing data.
- Should further constraints be implemented (eg. a negative-constraint or non-zero)?
- Should this behaviour be covered in any of the test cases (eg. `test_future_reg`)?