### PR TITLE
FIX: NaN IDs output in the predict method for Multiple Time Series

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2599,7 +2599,6 @@ class NeuralProphet:
         # Receives df with single ID column
         assert len(df["ID"].unique()) == 1
         cols = ["ds", "y", "ID"]  # cols to keep from df
-        df = df.reset_index(drop=True)
         df_forecast = pd.concat((df[cols],), axis=1)
         # create a line for each forecast_lag
         # 'yhat<i>' is the forecast for 'y' at 'ds' from i steps ago.
@@ -2635,5 +2634,7 @@ class NeuralProphet:
                 forecast_0 = components[comp][0, :]
                 forecast_rest = components[comp][1:, self.n_forecasts - 1]
                 yhat = np.concatenate(([None] * self.max_lags, forecast_0, forecast_rest))
-                df_forecast = pd.concat([df_forecast, pd.Series(yhat, name=comp)], axis=1, ignore_index=False)
+                df_forecast = pd.concat(
+                    [df_forecast, pd.Series(yhat, name=comp).set_axis(df_forecast.index)], axis=1, ignore_index=False
+                )
         return df_forecast

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2599,6 +2599,7 @@ class NeuralProphet:
         # Receives df with single ID column
         assert len(df["ID"].unique()) == 1
         cols = ["ds", "y", "ID"]  # cols to keep from df
+        df = df.reset_index(drop=True)
         df_forecast = pd.concat((df[cols],), axis=1)
         # create a line for each forecast_lag
         # 'yhat<i>' is the forecast for 'y' at 'ds' from i steps ago.

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2634,7 +2634,7 @@ class NeuralProphet:
                 forecast_0 = components[comp][0, :]
                 forecast_rest = components[comp][1:, self.n_forecasts - 1]
                 yhat = np.concatenate(([None] * self.max_lags, forecast_0, forecast_rest))
-                df_forecast = pd.concat(
-                    [df_forecast, pd.Series(yhat, name=comp).set_axis(df_forecast.index)], axis=1, ignore_index=False
-                )
+                # yhat into dataframe, using df_forecast indexing
+                yhat_df = pd.Series(yhat, name=comp).set_axis(df_forecast.index)
+                df_forecast = pd.concat([df_forecast, yhat_df], axis=1, ignore_index=False)
         return df_forecast


### PR DESCRIPTION
Hi @ourownstory @karl-richter ,

When using the global_modeling tutorial I realised that when forecasting multiple time series, the output of the `predict` method gives some NaNs IDs (see picture attached).

I had a look and the problem might come from #656 and, in particular, from the method `_reshape_raw_predictions_to_forecst_df`. At the end of this method we have:

`df_forecast = pd.concat([df_forecast, pd.Series(yhat, name=comp)], axis=1, ignore_index=False)`

the problem is that the index in `df_forecast` and `pd.Series(yhat, name=comp)` do match if only 1 time series is passed or in the first time series passed when passing multiple. However the `df_forecast` of the second time series passed, has an indexation that wont match the `pd.Series`.

I think resetting the index at the start of the method should work. Let me know what you think!

![WhatsApp Image 2022-07-24 at 6 45 43 PM](https://user-images.githubusercontent.com/35847472/180659561-2d4eacb0-143d-4eb6-a1ce-736ac6a52ab0.jpeg)

