### PR TITLE
Write test cases for events and holidays regularization

### DIFF
--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import os
-import pathlib
 import random
 
 import numpy as np
@@ -19,10 +17,6 @@ random.seed(0)
 np.random.seed(0)
 
 # Variables
-DIR = pathlib.Path(__file__).parent.parent.absolute()
-DATA_DIR = os.path.join(DIR, "tests", "test-data")
-PEYTON_FILE = os.path.join(DATA_DIR, "wp_log_peyton_manning.csv")
-
 EPOCHS = 10
 BATCH_SIZE_HOLIDAYS = 32
 BATCH_SIZE_EVENTS = 3

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -21,7 +21,7 @@ EPOCHS = 10
 BATCH_SIZE_HOLIDAYS = 32
 BATCH_SIZE_EVENTS = 1
 LEARNING_RATE = 0.1
-REGULARIZATION = 0.02
+REGULARIZATION = 0.01
 # Map holiday name to a y value for dataset generation
 Y_HOLIDAYS_OVERRIDE = {
     "Washington's Birthday": 10,

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -24,10 +24,10 @@ DATA_DIR = os.path.join(DIR, "tests", "test-data")
 PEYTON_FILE = os.path.join(DATA_DIR, "wp_log_peyton_manning.csv")
 
 NROWS = 100
-EPOCHS = 50
-BATCH_SIZE = 64
-LR = 1.0
-REGULARIZATION = 1e20
+EPOCHS = 10
+BATCH_SIZE = 32
+LEARNING_RATE = 0.1
+REGULARIZATION = 10
 
 
 def test_reg_func_abs():
@@ -48,9 +48,13 @@ def test_regularization_holidays():
     df = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(
+        yearly_seasonality=False,
+        weekly_seasonality=False,
+        daily_seasonality=False,
+        growth="off",
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,
-        learning_rate=LR,
+        learning_rate=LEARNING_RATE,
     )
     m = m.add_country_holidays("US", regularization=REGULARIZATION)
     m.fit(df, freq="D")
@@ -58,7 +62,7 @@ def test_regularization_holidays():
     for country_holiday in m.country_holidays_config.holiday_names:
         event_params = m.model.get_event_weights(country_holiday)
         weight_list = [param.detach().numpy() for _, param in event_params.items()]
-        assert weight_list[0] < 0.05
+        assert weight_list[0] < 0.5
 
 
 def test_regularization_holidays_disabled():
@@ -66,9 +70,13 @@ def test_regularization_holidays_disabled():
     df = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(
+        yearly_seasonality=False,
+        weekly_seasonality=False,
+        daily_seasonality=False,
+        growth="off",
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,
-        learning_rate=LR,
+        learning_rate=LEARNING_RATE,
     )
     m = m.add_country_holidays("US", regularization=0)
     m.fit(df, freq="D")
@@ -76,7 +84,7 @@ def test_regularization_holidays_disabled():
     for country_holiday in m.country_holidays_config.holiday_names:
         event_params = m.model.get_event_weights(country_holiday)
         weight_list = [param.detach().numpy() for _, param in event_params.items()]
-        assert np.abs(weight_list[0]) > 0.05
+        assert weight_list[0] >= 0.5
 
 
 def test_regularization_events():
@@ -84,9 +92,13 @@ def test_regularization_events():
     df = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(
+        yearly_seasonality=False,
+        weekly_seasonality=False,
+        daily_seasonality=False,
+        growth="off",
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,
-        learning_rate=LR,
+        learning_rate=LEARNING_RATE,
     )
     m = m.add_events("special_day", regularization=REGULARIZATION)
     events_df = pd.DataFrame(
@@ -108,9 +120,13 @@ def test_regularization_events_disabled():
     df = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(
+        yearly_seasonality=False,
+        weekly_seasonality=False,
+        daily_seasonality=False,
+        growth="off",
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,
-        learning_rate=LR,
+        learning_rate=LEARNING_RATE,
     )
     m = m.add_events("special_day", regularization=0)
     events_df = pd.DataFrame(

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+import random
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from neuralprophet import NeuralProphet, df_utils
+from neuralprophet.utils import reg_func_abs
+
+# Fix random seeds
+torch.manual_seed(0)
+random.seed(0)
+np.random.seed(0)
+
+# Variables
+DIR = pathlib.Path(__file__).parent.parent.absolute()
+DATA_DIR = os.path.join(DIR, "tests", "test-data")
+PEYTON_FILE = os.path.join(DATA_DIR, "wp_log_peyton_manning.csv")
+
+NROWS = 100
+EPOCHS = 50
+BATCH_SIZE = 64
+LR = 1.0
+REGULARIZATION = 1e20
+
+
+def test_reg_func_abs():
+    assert pytest.approx(1) == reg_func_abs(torch.Tensor([1]))
+    assert pytest.approx(0) == reg_func_abs(torch.Tensor([0]))
+    assert pytest.approx(1) == reg_func_abs(torch.Tensor([-1]))
+
+    assert pytest.approx(1) == reg_func_abs(torch.Tensor([1, 1, 1]))
+    assert pytest.approx(0) == reg_func_abs(torch.Tensor([0, 0, 0]))
+    assert pytest.approx(1) == reg_func_abs(torch.Tensor([-1, -1, -1]))
+
+    assert pytest.approx(0.6666666) == reg_func_abs(torch.Tensor([-1, 0, 1]))
+    assert pytest.approx(20) == reg_func_abs(torch.Tensor([-12, 4, 0, -1, 1, 102]))
+
+
+def test_regularization_holidays():
+    df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    df = df_utils.check_dataframe(df, check_y=False)
+
+    m = NeuralProphet(
+        epochs=EPOCHS,
+        batch_size=BATCH_SIZE,
+        learning_rate=LR,
+    )
+    m = m.add_country_holidays("US", regularization=REGULARIZATION)
+    m.fit(df, freq="D")
+
+    for country_holiday in m.country_holidays_config.holiday_names:
+        event_params = m.model.get_event_weights(country_holiday)
+        weight_list = [param.detach().numpy() for _, param in event_params.items()]
+        assert weight_list[0] < 0.05
+
+
+def test_regularization_holidays_disabled():
+    df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    df = df_utils.check_dataframe(df, check_y=False)
+
+    m = NeuralProphet(
+        epochs=EPOCHS,
+        batch_size=BATCH_SIZE,
+        learning_rate=LR,
+    )
+    m = m.add_country_holidays("US", regularization=0)
+    m.fit(df, freq="D")
+
+    for country_holiday in m.country_holidays_config.holiday_names:
+        event_params = m.model.get_event_weights(country_holiday)
+        weight_list = [param.detach().numpy() for _, param in event_params.items()]
+        assert np.abs(weight_list[0]) > 0.05
+
+
+def test_regularization_events():
+    df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    df = df_utils.check_dataframe(df, check_y=False)
+
+    m = NeuralProphet(
+        epochs=EPOCHS,
+        batch_size=BATCH_SIZE,
+        learning_rate=LR,
+    )
+    m = m.add_events("special_day", regularization=REGULARIZATION)
+    events_df = pd.DataFrame(
+        {
+            "event": "special_day",
+            "ds": pd.to_datetime(["2008-02-04"]),
+        }
+    )
+    history_df = m.create_df_with_events(df, events_df)
+    m.fit(history_df, freq="D")
+
+    weight_list = m.model.get_event_weights("special_day")
+    for _, param in weight_list.items():
+        assert param.detach().numpy() < 0.01
+
+
+def test_regularization_events_disabled():
+    df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    df = df_utils.check_dataframe(df, check_y=False)
+
+    m = NeuralProphet(
+        epochs=EPOCHS,
+        batch_size=BATCH_SIZE,
+        learning_rate=LR,
+    )
+    m = m.add_events("special_day", regularization=0)
+    events_df = pd.DataFrame(
+        {
+            "event": "special_day",
+            "ds": pd.to_datetime(["2008-02-04"]),
+        }
+    )
+    history_df = m.create_df_with_events(df, events_df)
+    m.fit(history_df, freq="D")
+
+    weight_list = m.model.get_event_weights("special_day")
+    for _, param in weight_list.items():
+        # assert param.detach().numpy() == pytest.approx(0.9358184337615967)
+        assert param.detach().numpy() > 0.9

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -24,7 +24,8 @@ DATA_DIR = os.path.join(DIR, "tests", "test-data")
 PEYTON_FILE = os.path.join(DATA_DIR, "wp_log_peyton_manning.csv")
 
 EPOCHS = 10
-BATCH_SIZE = 32
+BATCH_SIZE_HOLIDAYS = 32
+BATCH_SIZE_EVENTS = 3
 LEARNING_RATE = 0.1
 REGULARIZATION = 10
 
@@ -52,7 +53,7 @@ def test_regularization_holidays():
         daily_seasonality=False,
         growth="off",
         epochs=EPOCHS,
-        batch_size=BATCH_SIZE,
+        batch_size=BATCH_SIZE_HOLIDAYS,
         learning_rate=LEARNING_RATE,
     )
     m = m.add_country_holidays("US", regularization=REGULARIZATION)
@@ -74,7 +75,7 @@ def test_regularization_holidays_disabled():
         daily_seasonality=False,
         growth="off",
         epochs=EPOCHS,
-        batch_size=BATCH_SIZE,
+        batch_size=BATCH_SIZE_HOLIDAYS,
         learning_rate=LEARNING_RATE,
     )
     m = m.add_country_holidays("US", regularization=0)
@@ -96,7 +97,7 @@ def test_regularization_events():
         daily_seasonality=False,
         growth="off",
         epochs=EPOCHS,
-        batch_size=BATCH_SIZE,
+        batch_size=BATCH_SIZE_EVENTS,
         learning_rate=LEARNING_RATE,
     )
     m = m.add_events(["event_%i" % index for index, _ in enumerate(events)], regularization=REGULARIZATION)
@@ -130,7 +131,7 @@ def test_regularization_events_disabled():
         daily_seasonality=False,
         growth="off",
         epochs=EPOCHS,
-        batch_size=BATCH_SIZE,
+        batch_size=BATCH_SIZE_EVENTS,
         learning_rate=LEARNING_RATE,
     )
     m = m.add_events(["event_%i" % index for index, _ in enumerate(events)], regularization=0)

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -24,12 +24,12 @@ LEARNING_RATE = 0.1
 REGULARIZATION = 10
 # Map holiday name to a y value for dataset generation
 Y_HOLIDAYS_OVERRIDE = {
-    "Washington's Birthday": 1,
-    "Labor Day": 5,
-    "Christmas Day": 1,
+    "Washington's Birthday": 10,
+    "Labor Day": 10,
+    "Christmas Day": 10,
 }
 Y_EVENTS_OVERRIDE = {
-    "2022-01-13": 1,
+    "2022-01-13": 10,
 }
 
 

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -112,7 +112,7 @@ def test_regularization_events():
 
     weight_list = m.model.get_event_weights("special_day")
     for _, param in weight_list.items():
-        assert param.detach().numpy() < 0.01
+        assert param.detach().numpy() < 0.5
 
 
 def test_regularization_events_disabled():
@@ -140,5 +140,4 @@ def test_regularization_events_disabled():
 
     weight_list = m.model.get_event_weights("special_day")
     for _, param in weight_list.items():
-        # assert param.detach().numpy() == pytest.approx(0.9358184337615967)
-        assert param.detach().numpy() > 0.9
+        assert param.detach().numpy() > 0.5

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -11,6 +11,7 @@ import torch
 
 from neuralprophet import NeuralProphet, df_utils
 from neuralprophet.utils import reg_func_abs
+from utils.dataset_generators import generate_holiday_dataset
 
 # Fix random seeds
 torch.manual_seed(0)
@@ -43,7 +44,7 @@ def test_reg_func_abs():
 
 
 def test_regularization_holidays():
-    df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    df = generate_holiday_dataset()
     df = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(
@@ -61,7 +62,7 @@ def test_regularization_holidays():
 
 
 def test_regularization_holidays_disabled():
-    df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    df = generate_holiday_dataset()
     df = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -21,7 +21,7 @@ EPOCHS = 10
 BATCH_SIZE_HOLIDAYS = 32
 BATCH_SIZE_EVENTS = 1
 LEARNING_RATE = 0.1
-REGULARIZATION = 10
+REGULARIZATION = 0.02
 # Map holiday name to a y value for dataset generation
 Y_HOLIDAYS_OVERRIDE = {
     "Washington's Birthday": 10,

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -66,9 +66,9 @@ def test_regularization_holidays():
         event_params = m.model.get_event_weights(country_holiday)
         weight_list = [param.detach().numpy() for _, param in event_params.items()]
         if country_holiday in Y_HOLIDAYS_OVERRIDE.keys():
-            assert weight_list[0] <= 0.1
+            assert weight_list[0] < 0.1
         else:
-            assert weight_list[0] >= 0.5
+            assert weight_list[0] > 0.5
 
 
 def test_regularization_events():
@@ -103,6 +103,6 @@ def test_regularization_events():
         weight_list = m.model.get_event_weights("event_%i" % index)
         for _, param in weight_list.items():
             if event in Y_EVENTS_OVERRIDE.keys():
-                assert param.detach().numpy() <= 0.1
+                assert param.detach().numpy() < 0.1
             else:
-                assert param.detach().numpy() >= 0.5
+                assert param.detach().numpy() > 0.5

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -68,7 +68,7 @@ def test_regularization_holidays():
         if country_holiday in Y_HOLIDAYS_OVERRIDE.keys():
             assert weight_list[0] <= 0.1
         else:
-            assert weight_list[0] <= 0.5
+            assert weight_list[0] >= 0.5
 
 
 def test_regularization_events():
@@ -105,4 +105,4 @@ def test_regularization_events():
             if event in Y_EVENTS_OVERRIDE.keys():
                 assert param.detach().numpy() <= 0.1
             else:
-                assert param.detach().numpy() <= 0.5
+                assert param.detach().numpy() >= 0.5

--- a/tests/utils/dataset_generators.py
+++ b/tests/utils/dataset_generators.py
@@ -3,7 +3,7 @@ import pandas as pd
 from neuralprophet.time_dataset import make_country_specific_holidays_df
 
 
-def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=1000, y_holidays_override={}):
+def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=100, y_holidays_override={}):
     """Generate dataset with special y values for country holidays."""
 
     periods = len(years) * 365
@@ -21,7 +21,7 @@ def generate_event_dataset(
     events=["2022-01-01", "2022-01-10", "2022-01-13", "2022-01-31"],
     periods=31,
     y_default=1,
-    y_event=1000,
+    y_event=100,
     y_events_override={},
 ):
     """Generate dataset with regular y value and special y value for events."""

--- a/tests/utils/dataset_generators.py
+++ b/tests/utils/dataset_generators.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from neuralprophet.time_dataset import make_country_specific_holidays_df
+
+
+def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=1000):
+    """Generate dataset with special y values for country holidays."""
+
+    periods = len(years) * 365
+    dates = pd.date_range("%i-01-01" % (years[0]), periods=periods, freq="D")
+    df = pd.DataFrame({"ds": dates, "y": y_default}, index=dates)
+
+    holidays = make_country_specific_holidays_df(years, country)
+    for holiday, timestamps in holidays.items():
+        df.loc[timestamps[0], "y"] = y_holiday
+
+    return df

--- a/tests/utils/dataset_generators.py
+++ b/tests/utils/dataset_generators.py
@@ -15,3 +15,16 @@ def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=
         df.loc[timestamps[0], "y"] = y_holiday
 
     return df
+
+
+def generate_event_dataset(events=["2022-01-01", "2022-01-10", "2022-01-31"], periods=31, y_default=1, y_event=1000):
+    """Generate dataset with regular y value and special y value for events."""
+    events.sort()
+
+    dates = pd.date_range(events[0], periods=periods, freq="D")
+    df = pd.DataFrame({"ds": dates, "y": y_default}, index=dates)
+
+    for event in events:
+        df.loc[event, "y"] = y_event
+
+    return df, events

--- a/tests/utils/dataset_generators.py
+++ b/tests/utils/dataset_generators.py
@@ -11,7 +11,7 @@ def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=
     df = pd.DataFrame({"ds": dates, "y": y_default}, index=dates)
 
     holidays = make_country_specific_holidays_df(years, country)
-    for holiday, timestamps in holidays.items():
+    for timestamps in holidays.values():
         df.loc[timestamps[0], "y"] = y_holiday
 
     return df

--- a/tests/utils/dataset_generators.py
+++ b/tests/utils/dataset_generators.py
@@ -3,7 +3,7 @@ import pandas as pd
 from neuralprophet.time_dataset import make_country_specific_holidays_df
 
 
-def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=1000):
+def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=1000, y_holidays_override={}):
     """Generate dataset with special y values for country holidays."""
 
     periods = len(years) * 365
@@ -11,8 +11,8 @@ def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=
     df = pd.DataFrame({"ds": dates, "y": y_default}, index=dates)
 
     holidays = make_country_specific_holidays_df(years, country)
-    for timestamps in holidays.values():
-        df.loc[timestamps[0], "y"] = y_holiday
+    for holiday_name, timestamps in holidays.items():
+        df.loc[timestamps[0], "y"] = y_holidays_override.get(holiday_name, y_holiday)
 
     return df
 

--- a/tests/utils/dataset_generators.py
+++ b/tests/utils/dataset_generators.py
@@ -17,7 +17,13 @@ def generate_holiday_dataset(country="US", years=[2022], y_default=1, y_holiday=
     return df
 
 
-def generate_event_dataset(events=["2022-01-01", "2022-01-10", "2022-01-31"], periods=31, y_default=1, y_event=1000):
+def generate_event_dataset(
+    events=["2022-01-01", "2022-01-10", "2022-01-13", "2022-01-31"],
+    periods=31,
+    y_default=1,
+    y_event=1000,
+    y_events_override={},
+):
     """Generate dataset with regular y value and special y value for events."""
     events.sort()
 
@@ -25,6 +31,6 @@ def generate_event_dataset(events=["2022-01-01", "2022-01-10", "2022-01-31"], pe
     df = pd.DataFrame({"ds": dates, "y": y_default}, index=dates)
 
     for event in events:
-        df.loc[event, "y"] = y_event
+        df.loc[event, "y"] = y_events_override.get(event, y_event)
 
     return df, events


### PR DESCRIPTION
A collection of test cases to check regularization functions. Contains some unit tests for base functions and several integration tests to ensure higher regularization values results in lower weights (high regularization -> weights close to zero).

Pull request to add tests for issue #133 