### PR TITLE
Editorconfig: Fix indention for Makefile, yml and bat files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yml]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ insert_final_newline = true
 
 [*.yml]
 indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+
+[*.bat]
+indent_style = tab


### PR DESCRIPTION
All `yml` files in the project have an indention of 2 spaces. `Makefile` and `bat` files requires indention to be tabs. Editorconfig now preserves this choice.