### PR TITLE
Plotly quantile support

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1453,6 +1453,7 @@ class NeuralProphet:
             log.info("Plotly does not support plotting of quantiles yet.")
             return plot_plotly(
                 fcst=fcst,
+                quantiles=self.config_train.quantiles,
                 xlabel=xlabel,
                 ylabel=ylabel,
                 figsize=tuple(x * 70 for x in figsize),

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -537,6 +537,9 @@ class NeuralProphet:
         and create the corresponding configs such as lower, upper windows and the regularization
         parameters
 
+        Holidays can only be added for a single country. Calling the function
+        multiple times will override already added country holidays.
+
         Parameters
         ----------
             country_name : string
@@ -552,6 +555,10 @@ class NeuralProphet:
         """
         if self.fitted:
             raise Exception("Country must be specified prior to model fitting.")
+        if self.country_holidays_config:
+            log.warning(
+                "Country holidays can only be added for a single country. Previous country holidays were overridden."
+            )
 
         if regularization is not None:
             if regularization < 0:

--- a/neuralprophet/plot_forecast_plotly.py
+++ b/neuralprophet/plot_forecast_plotly.py
@@ -47,7 +47,7 @@ def plot(fcst, quantiles, xlabel="ds", ylabel="y", highlight_forecast=None, line
         fcst : pd.DataFrame
             Output of m.predict
         quantiles: list
-            Quantiles for which the forecasts are to be plotted
+            Quantiles for which the forecasts are to be plotted.
         xlabel : str
             Label name on X-axis
         ylabel : str

--- a/neuralprophet/plot_forecast_plotly.py
+++ b/neuralprophet/plot_forecast_plotly.py
@@ -38,7 +38,7 @@ layout_args = {
 }
 
 
-def plot(fcst, xlabel="ds", ylabel="y", highlight_forecast=None, line_per_origin=False, figsize=(700, 210)):
+def plot(fcst, quantiles, xlabel="ds", ylabel="y", highlight_forecast=None, line_per_origin=False, figsize=(700, 210)):
     """
     Plot the NeuralProphet forecast
 
@@ -46,6 +46,8 @@ def plot(fcst, xlabel="ds", ylabel="y", highlight_forecast=None, line_per_origin
     ---------
         fcst : pd.DataFrame
             Output of m.predict
+        quantiles: list
+            Quantiles for which the forecasts are to be plotted
         xlabel : str
             Label name on X-axis
         ylabel : str
@@ -73,16 +75,43 @@ def plot(fcst, xlabel="ds", ylabel="y", highlight_forecast=None, line_per_origin
 
     if highlight_forecast is None or line_per_origin:
         for i, yhat_col_name in enumerate(yhat_col_names):
-            data.append(
-                go.Scatter(
-                    name=yhat_col_name,
-                    x=ds,
-                    y=fcst["yhat{}".format(i + 1)],
-                    mode="lines",
-                    line=dict(color=f"rgba(45, 146, 255, {0.2 + 2.0 / (i + 2.5)})", width=line_width),
-                    fill="none",
+            if "%" not in yhat_col_name:
+                data.append(
+                    go.Scatter(
+                        name=yhat_col_name,
+                        x=ds,
+                        y=fcst["yhat{}".format(i + 1)],
+                        mode="lines",
+                        line=dict(color=f"rgba(45, 146, 255, {0.2 + 2.0 / (i + 2.5)})", width=line_width),
+                        fill="none",
+                    )
                 )
-            )
+    if len(quantiles) > 1 and highlight_forecast is None:
+        for i in range(1, len(quantiles)):
+            # skip fill="tonexty" for the first quantile
+            if i == 1:
+                data.append(
+                    go.Scatter(
+                        name="yhat1 {}%".format(quantiles[i] * 100),
+                        x=ds,
+                        y=fcst["yhat1 {}%".format(quantiles[i] * 100)],
+                        mode="lines",
+                        line=dict(color="rgba(45, 146, 255, 0.2)", width=1),
+                        fillcolor="rgba(45, 146, 255, 0.2)",
+                    )
+                )
+            else:
+                data.append(
+                    go.Scatter(
+                        name="yhat1 {}%".format(quantiles[i] * 100),
+                        x=ds,
+                        y=fcst["yhat1 {}%".format(quantiles[i] * 100)],
+                        mode="lines",
+                        line=dict(color="rgba(45, 146, 255, 0.2)", width=1),
+                        fill="tonexty",
+                        fillcolor="rgba(45, 146, 255, 0.2)",
+                    )
+                )
 
     if highlight_forecast is not None:
         if line_per_origin:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -328,3 +328,17 @@ def test_plotly_future_reg():
         fig1.show()
         fig2.show()
         fig3.show()
+
+
+def test_plotly_uncertainty():
+    log.info("testing: Plotting with plotly")
+    df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    m = NeuralProphet(quantiles=[0.9, 0.2, 0.1])
+    metrics_df = m.fit(df, freq="D")
+
+    future = m.make_future_dataframe(df, periods=30, n_historic_predictions=100)
+    forecast = m.predict(future)
+    fig1 = m.plot(forecast, plotting_backend="plotly")
+
+    if PLOT:
+        fig1.show()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -896,3 +896,16 @@ def test_version():
     metadata_version_ = metadata.version("neuralprophet")
     assert metadata_version_ == init_version
     assert metadata_version_ == file_version
+
+
+def test_add_country_holiday_multiple_calls_warning(caplog):
+    error_message = (
+        "Country holidays can only be added for a single country. Previous country holidays were overridden."
+    )
+
+    m = NeuralProphet()
+    m.add_country_holidays("US")
+    assert error_message not in caplog.text
+
+    m.add_country_holidays("Germany")
+    assert error_message in caplog.text


### PR DESCRIPTION
Added support for the plotting of uncertainty quantiles to plotly.
Tested with the feature-use tutorial notebooks created by @Kevin-Chen0. 
Added plotting test for the plotly uncertainty plotting functionality.

Building on the ideas by #368, but created a new PR due to incompatible changes.