### PR TITLE
[bugfix] Addressed np.quantile issue

### DIFF
--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -339,7 +339,10 @@ def get_normalization_params(array, norm_type):
     non_nan_array = array[~np.isnan(array)]
     if norm_type == "soft":
         lowest = np.min(non_nan_array)
-        q95 = np.quantile(non_nan_array, 0.95, method="higher")
+        if np.__version__ >= "1.22.0":
+            q95 = np.quantile(non_nan_array, 0.95, method="higher")
+        else:
+            q95 = np.quantile(non_nan_array, 0.95, interpolation="higher")
         width = q95 - lowest
         if math.isclose(width, 0):
             width = np.max(non_nan_array) - lowest
@@ -347,7 +350,10 @@ def get_normalization_params(array, norm_type):
         scale = width
     elif norm_type == "soft1":
         lowest = np.min(non_nan_array)
-        q90 = np.quantile(non_nan_array, 0.9, method="higher")
+        if np.__version__ >= "1.22.0":
+            q90 = np.quantile(non_nan_array, 0.9, method="higher")
+        else:
+            q90 = np.quantile(non_nan_array, 0.9, interpolation="higher")
         width = q90 - lowest
         if math.isclose(width, 0):
             width = (np.max(non_nan_array) - lowest) / 1.25

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -339,10 +339,7 @@ def get_normalization_params(array, norm_type):
     non_nan_array = array[~np.isnan(array)]
     if norm_type == "soft":
         lowest = np.min(non_nan_array)
-        if np.__version__ >= "1.22.0":
-            q95 = np.quantile(non_nan_array, 0.95, method="higher")
-        else:
-            q95 = np.quantile(non_nan_array, 0.95, interpolation="higher")
+        q95 = np.quantile(non_nan_array, 0.95)
         width = q95 - lowest
         if math.isclose(width, 0):
             width = np.max(non_nan_array) - lowest
@@ -350,10 +347,7 @@ def get_normalization_params(array, norm_type):
         scale = width
     elif norm_type == "soft1":
         lowest = np.min(non_nan_array)
-        if np.__version__ >= "1.22.0":
-            q90 = np.quantile(non_nan_array, 0.9, method="higher")
-        else:
-            q90 = np.quantile(non_nan_array, 0.9, interpolation="higher")
+        q90 = np.quantile(non_nan_array, 0.9)
         width = q90 - lowest
         if math.isclose(width, 0):
             width = (np.max(non_nan_array) - lowest) / 1.25


### PR DESCRIPTION
In #684, users addressed that the `np.quantile` function is incompatible with any Python version lower than 3.8.
This is due to a change in the Numpy api introduced with version 1.22.0, however, this version is not compatible with any older Python version.

In the [Numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.quantile.html), the developers state that they renamed the `method` function argument (previously: `interpolation`) and added argument options. Since the option we are using (`method="higher"`) has previously been available, the simple solution I propose is to wrap the statement with a conditional that switches between the old and the new function call based on the installed Numpy version. The `np.quantile` is only called two times in the same function within the whole repo, this solution adds only a minor technical overhead.

Let me know what you are thinking!

```python
if np.__version__ >= "1.22.0":
      q95 = np.quantile(non_nan_array, 0.95, method="higher")
else:
      q95 = np.quantile(non_nan_array, 0.95, interpolation="higher")
```
