### PR TITLE
remove print statement from forecaster.py

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -325,7 +325,6 @@ class NeuralProphet:
         unknown_data_normalization=False,
     ):
         kwargs = locals()
-        print(kwargs)
 
         # General
         self.name = "NeuralProphet"


### PR DESCRIPTION
Removed some left over debug print statement. In case we want to keep it, better move it to logging.