### PR TITLE
[feature] add uncertainty plot in separate panel to plot_components() 

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2899,6 +2899,9 @@ class NeuralProphet:
                         if j == 0:  # temporary condition to add only the median component
                             name = "{}{}".format(comp, forecast_lag)
                             df_forecast[name] = yhat
+                        # if j > 0:  # temporary condition to further add the other quantile components
+                        #         name = "{}{}{}%".format(comp, forecast_lag, self.config_train.quantiles[j] * 100)
+                        #         df_forecast[name] = yhat
 
         # only for non-lagged components
         for comp in components:
@@ -2911,4 +2914,8 @@ class NeuralProphet:
                         # add yhat into dataframe, using df_forecast indexing
                         yhat_df = pd.Series(yhat, name=comp).set_axis(df_forecast.index)
                         df_forecast = pd.concat([df_forecast, yhat_df], axis=1, ignore_index=False)
+                    # elif j > 0:  # temporary condition to further add the other quantile components
+                    #     name = "{} {}%".format(comp, self.config_train.quantiles[j] * 100)
+                    #     yhat_df = pd.Series(yhat, name=name).set_axis(df_forecast.index)
+                    #     df_forecast = pd.concat([df_forecast, yhat_df], axis=1, ignore_index=False)
         return df_forecast

--- a/neuralprophet/plot_forecast.py
+++ b/neuralprophet/plot_forecast.py
@@ -94,7 +94,7 @@ def plot(
                     alpha=0.2 + 2.0 / (i + 2.5),
                     label="yhat{}".format(i + 1),
                 )
-
+    # plot quantiles
     if len(quantiles) > 1 and highlight_forecast is None:
         for i in range(1, len(quantiles)):
             ax.fill_between(
@@ -118,7 +118,7 @@ def plot(
                 ds, fcst["yhat{}".format(highlight_forecast)], ls="-", c="b", label="yhat{}".format(highlight_forecast)
             )
             ax.plot(ds, fcst["yhat{}".format(highlight_forecast)], "bx", label="yhat{}".format(highlight_forecast))
-
+            # plot quantiles
             if len(quantiles) > 1:
                 for i in range(1, len(quantiles)):
                     ax.fill_between(


### PR DESCRIPTION
Referencing issue #710 
**Problem**
The plot() function already includes plotting the uncertainty. However, the plot_components() function does not include plotting the uncertainty for each component. Further, having the components and uncertainty plotted in one panel is not intuitive to visually estimate the absolute uncertainty.

**Solution**
Modify the plot_components() function to plot the uncertainty for each selected component in a separate panel. Therefore, each component-specific function called in plot_components(), e.g., plot_weekly(), needs to be modified. Further, all combinations of settings should be considered.