### PR TITLE
Tooling config black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,6 @@ exclude = '''
   | .gitignore
 )
 '''
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203


### PR DESCRIPTION
Adjust `isort` and `flake8` configs to work with `black`.