### PR TITLE
[Feature] enable quantiles for get_latest_forecast() output df

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1532,7 +1532,7 @@ class NeuralProphet:
             fcst = fcst[-(include_previous_forecasts + self.n_forecasts) :]
         elif include_history_data is True:
             fcst = fcst
-        fcst = utils.fcst_df_to_last_forecast(fcst, n_last=1 + include_previous_forecasts)
+        fcst = utils.fcst_df_to_last_forecast(fcst, self.config_train.quantiles, n_last=1 + include_previous_forecasts)
         return fcst
 
     def plot_last_forecast(
@@ -1602,7 +1602,7 @@ class NeuralProphet:
             fcst = fcst[-(include_previous_forecasts + self.n_forecasts) :]
         elif plot_history_data is True:
             fcst = fcst
-        fcst = utils.fcst_df_to_last_forecast(fcst, n_last=1 + include_previous_forecasts)
+        fcst = utils.fcst_df_to_last_forecast(fcst, self.config_train.quantiles, n_last=1 + include_previous_forecasts)
 
         # Check whether the default plotting backend is overwritten
         plotting_backend = (
@@ -2058,9 +2058,7 @@ class NeuralProphet:
                 raise ValueError(f"Name {name!r} already used for an event.")
         if events and self.config_country_holidays is not None:
             if name in self.config_country_holidays.holiday_names:
-                raise ValueError(
-                    f"Name {name!r} is a holiday name in {self.config_country_holidays.country}."
-                )
+                raise ValueError(f"Name {name!r} is a holiday name in {self.config_country_holidays.country}.")
         if seasons and self.config_season is not None:
             if name in self.config_season.periods:
                 raise ValueError(f"Name {name!r} already used for a seasonality.")
@@ -2444,7 +2442,7 @@ class NeuralProphet:
                     metrics_live[f"val_log-{metrics_val[0]}"] = np.log(val_epoch_metrics[metrics_val[0]])
                     if plot_live_all_metrics and len(metrics_val) > 1:
                         for i in range(1, len(metrics_val)):
-                            metrics_live[f"val_{metrics_val[i]}" ] = val_epoch_metrics[metrics_val[i]]
+                            metrics_live[f"val_{metrics_val[i]}"] = val_epoch_metrics[metrics_val[i]]
                 live_loss.update(metrics_live)
                 if e % (1 + self.config_train.epochs // 20) == 0 or e + 1 == self.config_train.epochs:
                     live_loss.send()
@@ -2608,9 +2606,7 @@ class NeuralProphet:
         if self.max_lags > 0:
             if periods > 0 and periods != self.n_forecasts:
                 periods = self.n_forecasts
-                log.warning(
-                    f"Number of forecast steps is defined by n_forecasts. " "Adjusted to {self.n_forecasts}."
-                )
+                log.warning(f"Number of forecast steps is defined by n_forecasts. " "Adjusted to {self.n_forecasts}.")
 
         if periods > 0:
             future_df = df_utils.make_future_df(

--- a/neuralprophet/plot_forecast.py
+++ b/neuralprophet/plot_forecast.py
@@ -92,7 +92,7 @@ def plot(
                     ls="-",
                     c="#0072B2",
                     alpha=0.2 + 2.0 / (i + 2.5),
-                    label=f"yhat{i + 1}" ,
+                    label=f"yhat{i + 1}",
                 )
 
     if len(quantiles) > 1 and highlight_forecast is None:
@@ -109,21 +109,22 @@ def plot(
         if line_per_origin:
             num_forecast_steps = sum(fcst["yhat1"].notna())
             steps_from_last = num_forecast_steps - highlight_forecast
-            for i in range(len(yhat_col_names)):
+            yhat_col_names_no_qts = [
+                col_name for col_name in yhat_col_names if "yhat" in col_name and "%" not in col_name
+            ]
+            for i in range(len(yhat_col_names_no_qts)):
                 x = ds[-(1 + i + steps_from_last)]
                 y = fcst[f"yhat{i + 1}"].values[-(1 + i + steps_from_last)]
                 ax.plot(x, y, "bx")
         else:
-            ax.plot(
-                ds, fcst[f"yhat{highlight_forecast}" ], ls="-", c="b", label=f"yhat{highlight_forecast}"
-            )
+            ax.plot(ds, fcst[f"yhat{highlight_forecast}"], ls="-", c="b", label=f"yhat{highlight_forecast}")
             ax.plot(ds, fcst[f"yhat{highlight_forecast}"], "bx", label=f"yhat{highlight_forecast}")
 
             if len(quantiles) > 1:
                 for i in range(1, len(quantiles)):
                     ax.fill_between(
                         ds,
-                        fcst[f"yhat{highlight_forecast}" ],
+                        fcst[f"yhat{highlight_forecast}"],
                         fcst[f"yhat{highlight_forecast} {quantiles[i] * 100}%"],
                         color="#0072B2",
                         alpha=0.2,

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -41,8 +41,8 @@ def test_uncertainty_estimation_plot():
     forecast = m.predict(future)
     m.plot(forecast)
     # m.plot_last_forecast(forecast, include_previous_forecasts=10)
-    m.plot_components(forecast)
-    m.plot_parameters()
+    fig1 = m.plot_components(forecast)
+    fig2 = m.plot_parameters()
     if PLOT:
         plt.show()
     # With auto-regression enabled
@@ -58,10 +58,12 @@ def test_uncertainty_estimation_plot():
     future = m.make_future_dataframe(df, periods=m.n_forecasts, n_historic_predictions=10)
     forecast = m.predict(future)
     m.highlight_nth_step_ahead_of_each_forecast(m.n_forecasts)
-    m.plot(forecast)
-    m.plot_last_forecast(forecast, include_previous_forecasts=10)
-    m.plot_components(forecast)
-    m.plot_parameters()
+    fig0 = m.plot(forecast)
+    fig1 = m.plot_last_forecast(forecast, include_previous_forecasts=10)
+    fig2 = m.plot_last_forecast(forecast, include_previous_forecasts=10, plot_history_data=True)
+    fig3 = m.plot_last_forecast(forecast, include_previous_forecasts=10, plot_history_data=False)
+    fig4 = m.plot_components(forecast)
+    fig5 = m.plot_parameters()
     if PLOT:
         plt.show()
     ## Global Model Plot
@@ -176,9 +178,9 @@ def test_uncertainty_estimation_peyton_manning():
     # print(forecast.to_string())
 
     if PLOT:
-        m.plot(forecast)
-        m.plot_components(forecast)
-        m.plot_parameters()
+        fig1 = m.plot(forecast)
+        fig2 = m.plot_components(forecast)
+        fig3 = m.plot_parameters()
         plt.show()
 
 
@@ -200,10 +202,10 @@ def test_uncertainty_estimation_yosemite_temps():
     # print(forecast.to_string())
     m.highlight_nth_step_ahead_of_each_forecast(m.n_forecasts)
     if PLOT:
-        m.plot_last_forecast(forecast, include_previous_forecasts=3)
-        m.plot(forecast)
-        m.plot_components(forecast)
-        m.plot_parameters()
+        fig1 = m.plot_last_forecast(forecast, include_previous_forecasts=3)
+        fig2 = m.plot(forecast)
+        fig3 = m.plot_components(forecast)
+        fig4 = m.plot_parameters()
         plt.show()
 
 
@@ -254,7 +256,7 @@ def test_uncertainty_estimation_multiple_quantiles():
         # print(forecast.to_string())
 
         if PLOT:
-            m.plot(forecast)
-            m.plot_components(forecast)
-            m.plot_parameters()
+            fig1 = m.plot(forecast)
+            fig2 = m.plot_components(forecast)
+            fig3 = m.plot_parameters()
             plt.show()


### PR DESCRIPTION
Same changes as in PR #764, but now with develop as the base branch

*output df of utils.fcst_df_to_last_forecast() now contains quantile columns if quantiles are specified in the model

*quantile columns are generated in the same way as the yhat columns

*Added fig1 = plot_... to every plot function in test_uncertainty.py