### PR TITLE
[bug-fix] Enable predictions into unknown and known future in case of remaining NaN windows after imputation

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -395,6 +395,7 @@ class NeuralProphet:
 
         # set during prediction
         self.future_periods = None
+        self.predict_steps = self.n_forecasts
         # later set by user (optional)
         self.highlight_forecast_step_n = None
         self.true_ar_weights = None
@@ -648,6 +649,7 @@ class NeuralProphet:
         self.max_lags = df_utils.get_max_num_lags(self.config_covar, self.n_lags)
         if self.max_lags == 0 and self.n_forecasts > 1:
             self.n_forecasts = 1
+            self.predict_steps = 1
             log.warning(
                 "Changing n_forecasts to 1. Without lags, the forecast can be "
                 "computed for any future time, independent of lagged values"
@@ -722,6 +724,9 @@ class NeuralProphet:
         forecast = pd.DataFrame()
         for df_name, df_i in df.groupby("ID"):
             dates, predicted, components = self._predict_raw(df_i, df_name, include_components=decompose)
+            df_i = df_utils.drop_missing_from_df(
+                df_i, self.config_missing.drop_missing, self.predict_steps, self.n_lags
+            )
             if raw:
                 fcst = self._convert_raw_predictions_to_raw_df(dates, predicted, components)
                 if periods_added[df_name] > 0:
@@ -734,6 +739,7 @@ class NeuralProphet:
         df = df_utils.return_df_in_original_format(
             forecast, received_ID_col, received_single_time_series, received_dict
         )
+        self.predict_steps = self.n_forecasts
         return df
 
     def test(self, df):
@@ -1314,6 +1320,7 @@ class NeuralProphet:
                 config_season=self.config_season,
                 # n_lags=0,
                 # n_forecasts=1,
+                predict_steps=self.predict_steps,
                 predict_mode=True,
                 config_missing=self.config_missing,
             )
@@ -1821,6 +1828,7 @@ class NeuralProphet:
             predict_mode=predict_mode,
             n_lags=self.n_lags,
             n_forecasts=self.n_forecasts,
+            predict_steps=self.predict_steps,
             config_season=self.config_season,
             config_events=self.config_events,
             config_country_holidays=self.config_country_holidays,
@@ -1854,7 +1862,7 @@ class NeuralProphet:
         """
         # Receives df with single ID column
         assert len(df["ID"].unique()) == 1
-        if self.max_lags == 0 and not predicting:
+        if self.n_lags == 0 and not predicting:
             # we can drop rows with NA in y
             sum_na = sum(df["y"].isna())
             if sum_na > 0:
@@ -1862,7 +1870,7 @@ class NeuralProphet:
                 log.info(f"dropped {sum_na} NAN row in 'y'")
 
         # add missing dates for autoregression modelling
-        if self.max_lags > 0:
+        if self.n_lags > 0:
             df, missing_dates = df_utils.add_missing_dates_nan(df, freq=freq)
             if missing_dates > 0:
                 if self.config_missing.impute_missing:
@@ -1916,7 +1924,7 @@ class NeuralProphet:
 
         # impute missing values
         data_columns = []
-        if self.max_lags > 0:
+        if self.n_lags > 0:
             data_columns.append("y")
         if self.config_covar is not None:
             data_columns.extend(self.config_covar.keys())
@@ -2058,9 +2066,7 @@ class NeuralProphet:
                 raise ValueError(f"Name {name!r} already used for an event.")
         if events and self.config_country_holidays is not None:
             if name in self.config_country_holidays.holiday_names:
-                raise ValueError(
-                    f"Name {name!r} is a holiday name in {self.config_country_holidays.country}."
-                )
+                raise ValueError(f"Name {name!r} is a holiday name in {self.config_country_holidays.country}.")
         if seasons and self.config_season is not None:
             if name in self.config_season.periods:
                 raise ValueError(f"Name {name!r} already used for a seasonality.")
@@ -2444,7 +2450,7 @@ class NeuralProphet:
                     metrics_live[f"val_log-{metrics_val[0]}"] = np.log(val_epoch_metrics[metrics_val[0]])
                     if plot_live_all_metrics and len(metrics_val) > 1:
                         for i in range(1, len(metrics_val)):
-                            metrics_live[f"val_{metrics_val[i]}" ] = val_epoch_metrics[metrics_val[i]]
+                            metrics_live[f"val_{metrics_val[i]}"] = val_epoch_metrics[metrics_val[i]]
                 live_loss.update(metrics_live)
                 if e % (1 + self.config_train.epochs // 20) == 0 or e + 1 == self.config_train.epochs:
                     live_loss.send()
@@ -2608,9 +2614,7 @@ class NeuralProphet:
         if self.max_lags > 0:
             if periods > 0 and periods != self.n_forecasts:
                 periods = self.n_forecasts
-                log.warning(
-                    f"Number of forecast steps is defined by n_forecasts. " "Adjusted to {self.n_forecasts}."
-                )
+                log.warning(f"Number of forecast steps is defined by n_forecasts. " "Adjusted to {self.n_forecasts}.")
 
         if periods > 0:
             future_df = df_utils.make_future_df(
@@ -2628,6 +2632,7 @@ class NeuralProphet:
             else:
                 df = future_df
         df = df.reset_index(drop=True)
+        self.predict_steps = periods
         return df
 
     def _get_maybe_extend_periods(self, df):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -95,9 +95,9 @@ def test_df_utils_func():
     global_data_params = df_utils.init_data_params(df_global, normalize="soft1")
     global_data_params = df_utils.init_data_params(df_global, normalize="standardize")
 
-    log.debug(f"Time Threshold: \n {time_threshold}" )
-    log.debug(f"Df_train: \n {df_train}" )
-    log.debug(f"Df_val: \n {df_val}" )
+    log.debug(f"Time Threshold: \n {time_threshold}")
+    log.debug(f"Df_train: \n {df_train}")
+    log.debug(f"Df_val: \n {df_val}")
 
 
 def test_trend():
@@ -133,8 +133,8 @@ def test_custom_changepoints():
     dates = df["ds"][range(1, len(df) - 1, int(len(df) / 5.0))]
     dates_list = [str(d) for d in dates]
     dates_array = pd.to_datetime(dates_list).values
-    log.debug(f"dates: {dates}" )
-    log.debug(f"dates_list: {dates_list}" )
+    log.debug(f"dates: {dates}")
+    log.debug(f"dates_list: {dates_list}")
     log.debug(f"dates_array: {dates_array.dtype} {dates_array}")
     for cp in [dates_list, dates_array]:
         m = NeuralProphet(
@@ -437,7 +437,7 @@ def test_events():
     metrics_df = m.fit(history_df, freq="D")
     future = m.make_future_dataframe(df=history_df, events_df=events_df, periods=30, n_historic_predictions=90)
     forecast = m.predict(df=future)
-    log.debug(f"Event Parameters:: {m.model.event_params}" )
+    log.debug(f"Event Parameters:: {m.model.event_params}")
     if PLOT:
         m.plot_components(forecast)
         m.plot(forecast)
@@ -1477,19 +1477,39 @@ def test_drop_missing_values_after_imputation():
         batch_size=BATCH_SIZE,
         learning_rate=LR,
         n_lags=12,
-        n_forecasts=1,
+        n_forecasts=12,
         weekly_seasonality=True,
         impute_missing=True,
         impute_linear=10,
-        impute_rolling=10,
+        impute_rolling=0,
         drop_missing=True,
     )
     df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
-    # introduce large window of NaN values from which samples will be dropped after imputation
+    log.info("introducing two large NaN windows")
     df["y"][100:131] = np.nan
-    metrics = m.fit(df, freq="D", validation_df=None)
-    future = m.make_future_dataframe(df, periods=60, n_historic_predictions=60)
-    forecast = m.predict(df=future)
+    df["y"][170:200] = np.nan
+    metrics = m1.fit(df, freq="D", validation_df=None)
+    future = m1.make_future_dataframe(df, periods=60, n_historic_predictions=60)
+    forecast = m1.predict(df=df)
+    forecast = m1.predict(df=future)
+
+    log.info("Testing drop of remaining values after lin imputation, no lags")
+    m2 = NeuralProphet(
+        epochs=EPOCHS,
+        batch_size=BATCH_SIZE,
+        learning_rate=LR,
+        n_lags=0,
+        n_forecasts=12,
+        weekly_seasonality=True,
+        impute_missing=True,
+        impute_linear=10,
+        impute_rolling=0,
+        drop_missing=True,
+    )
+    metrics = m2.fit(df, freq="D", validation_df=None)
+    forecast = m2.predict(df=df)
+    future = m2.make_future_dataframe(df, periods=60, n_historic_predictions=60)
+    forecast = m2.predict(df=future)
 
 
 def test_dict_input():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1472,7 +1472,7 @@ def test_n_lags_for_regressors():
 
 
 def test_drop_missing_values_after_imputation():
-    m = NeuralProphet(
+    m1 = NeuralProphet(
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,
         learning_rate=LR,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -45,7 +45,7 @@ def test_impute_missing():
         df_na = df.copy(deep=True)
     to_fill = pd.isna(df_na["y"])
     # TODO fix debugging printout error
-    log.debug(f"sum(to_fill): {sum(to_fill.values)}" )
+    log.debug(f"sum(to_fill): {sum(to_fill.values)}")
     # df_filled, remaining_na = df_utils.fill_small_linear_large_trend(
     #     df.copy(deep=True),
     #     column=name,
@@ -72,7 +72,7 @@ def test_impute_missing():
 def test_time_dataset():
     # manually load any file that stores a time series, for example:
     df_in = pd.read_csv(AIR_FILE, index_col=False, nrows=NROWS)
-    log.debug(f"Infile shape: {df_in.shape}" )
+    log.debug(f"Infile shape: {df_in.shape}")
     n_lags = 3
     n_forecasts = 1
     valid_p = 0.2
@@ -282,14 +282,14 @@ def test_cv():
             for i in range(valid_fold_num)
         ]
         assert all([x == y for (x, y) in zip(train_folds_samples, train_folds_should)])
-        log.debug(f"total_samples: {total_samples}" )
-        log.debug(f"val_fold_each: {val_fold_each}" )
-        log.debug(f"overlap_each: {overlap_each}" )
-        log.debug(f"val_folds_len: {val_folds_len}" )
-        log.debug(f"val_folds_samples: {val_folds_samples}" )
-        log.debug(f"train_folds_len: {train_folds_len}" )
-        log.debug(f"train_folds_samples: {train_folds_samples}" )
-        log.debug(f"train_folds_should: {train_folds_should}" )
+        log.debug(f"total_samples: {total_samples}")
+        log.debug(f"val_fold_each: {val_fold_each}")
+        log.debug(f"overlap_each: {overlap_each}")
+        log.debug(f"val_folds_len: {val_folds_len}")
+        log.debug(f"val_folds_samples: {val_folds_samples}")
+        log.debug(f"train_folds_len: {train_folds_len}")
+        log.debug(f"train_folds_samples: {train_folds_samples}")
+        log.debug(f"train_folds_should: {train_folds_should}")
 
     len_df = 100
     check_folds(
@@ -350,16 +350,16 @@ def test_cv_for_global_model():
                 for i in range(valid_fold_num)
             ]
             assert all([x == y for (x, y) in zip(train_folds_samples, train_folds_should)])
-            log.debug(f"global_model_cv_type: {global_model_cv_type}" )
-            log.debug(f"df_name: {df_name}" )
-            log.debug(f"total_samples: {total_samples}" )
-            log.debug(f"val_fold_each: {val_fold_each}" )
-            log.debug(f"overlap_each: {overlap_each}" )
-            log.debug(f"val_folds_len: {val_folds_len}" )
-            log.debug(f"val_folds_samples: {val_folds_samples}" )
-            log.debug(f"train_folds_len: {train_folds_len}" )
-            log.debug(f"train_folds_samples: {train_folds_samples}" )
-            log.debug(f"train_folds_should: {train_folds_should}" )
+            log.debug(f"global_model_cv_type: {global_model_cv_type}")
+            log.debug(f"df_name: {df_name}")
+            log.debug(f"total_samples: {total_samples}")
+            log.debug(f"val_fold_each: {val_fold_each}")
+            log.debug(f"overlap_each: {overlap_each}")
+            log.debug(f"val_folds_len: {val_folds_len}")
+            log.debug(f"val_folds_samples: {val_folds_samples}")
+            log.debug(f"train_folds_len: {train_folds_len}")
+            log.debug(f"train_folds_samples: {train_folds_samples}")
+            log.debug(f"train_folds_should: {train_folds_should}")
         return folds
 
     # Test cv for dict with time series with similar time range
@@ -478,7 +478,7 @@ def test_reg_delay():
         (1, 8, 0),
     ]:
         weight = c.get_reg_delay_weight(e, i, reg_start_pct=0.5, reg_full_pct=0.8)
-        log.debug(f"e {e}, i {i}, expected w {w}, got w {weight}" )
+        log.debug(f"e {e}, i {i}, expected w {w}, got w {weight}")
         assert weight == w
 
 
@@ -506,9 +506,9 @@ def test_double_crossvalidation():
     assert train_folds_len2[0] == 85
     assert val_folds_len1[0] == 10
     assert val_folds_len2[0] == 5
-    log.debug(f"train_folds_len1: {train_folds_len1}" )
-    log.debug(f"val_folds_len1: {val_folds_len1}" )
-    log.debug(f"train_folds_len2: {train_folds_len2}" )
+    log.debug(f"train_folds_len1: {train_folds_len1}")
+    log.debug(f"val_folds_len1: {val_folds_len1}")
+    log.debug(f"train_folds_len2: {train_folds_len2}")
     log.debug(f"val_folds_len2: {val_folds_len2} ")
     log.info(f"Test m.double_crossvalidation_split_df")
     m = NeuralProphet(
@@ -537,10 +537,10 @@ def test_double_crossvalidation():
     assert train_folds_len2[0] == 88
     assert val_folds_len1[0] == 12
     assert val_folds_len2[0] == 6
-    log.debug(f"train_folds_len1: {train_folds_len1}" )
-    log.debug(f"val_folds_len1: {val_folds_len1}" )
-    log.debug(f"train_folds_len2: {train_folds_len2}" )
-    log.debug(f"val_folds_len2: {val_folds_len2}" )
+    log.debug(f"train_folds_len1: {train_folds_len1}")
+    log.debug(f"val_folds_len1: {val_folds_len1}")
+    log.debug(f"train_folds_len2: {train_folds_len2}")
+    log.debug(f"val_folds_len2: {val_folds_len2}")
     log.info("Raise not implemented error as double_crossvalidation is not compatible with many time series")
     with pytest.raises(NotImplementedError):
         df = pd.DataFrame({"ds": pd.date_range(start="2017-01-01", periods=len_df), "y": np.arange(len_df)})
@@ -769,14 +769,14 @@ def test_newer_sample_weight():
     # -> positive relationship of a and y
     dates = pd.date_range(start="2020-01-01", periods=100, freq="D")
     a = [1] * 100
-    y = [None] * 100
+    y = [0] * 100
     df = pd.DataFrame({"ds": dates, "y": y, "a": a})
     forecast1 = m.predict(df[:10])
     forecast2 = m.predict(df[-10:])
     avg_a1 = np.mean(forecast1["future_regressor_a"])
     avg_a2 = np.mean(forecast2["future_regressor_a"])
-    log.info(f"avg regressor a contribution first samples: {avg_a1}" )
-    log.info(f"avg regressor a contribution last samples: {avg_a2}" )
+    log.info(f"avg regressor a contribution first samples: {avg_a1}")
+    log.info(f"avg regressor a contribution last samples: {avg_a2}")
     # must hold
     assert avg_a1 > 0.1
     assert avg_a2 > 0.1
@@ -784,8 +784,8 @@ def test_newer_sample_weight():
     # this is less strict, as it also depends on trend, but should still hold
     avg_y1 = np.mean(forecast1["yhat1"])
     avg_y2 = np.mean(forecast2["yhat1"])
-    log.info(f"avg yhat first samples: {avg_y1}" )
-    log.info(f"avg yhat last samples: {avg_y2}" )
+    log.info(f"avg yhat first samples: {avg_y1}")
+    log.info(f"avg yhat last samples: {avg_y2}")
     assert avg_y1 > -0.9
     assert avg_y2 > 0.1
 
@@ -800,6 +800,7 @@ def test_make_future():
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,
         learning_rate=LR,
+        n_forecasts=10,
     )
     m = m.add_future_regressor(name="A")
     future = m.make_future_dataframe(
@@ -855,7 +856,7 @@ def test_too_many_NaN():
     df["ID"] = "__df__"
     # Check if ValueError is thrown, if NaN values remain after auto-imputing
     with pytest.raises(ValueError):
-        dataset = time_dataset.TimeDataset(df, "name", config_missing=config_missing)
+        dataset = time_dataset.TimeDataset(df, "name", config_missing=config_missing, predict_steps=1)
 
 
 def test_future_df_with_nan():
@@ -871,6 +872,23 @@ def test_future_df_with_nan():
     metrics = m.fit(df, freq="D")
     with pytest.raises(ValueError):
         future = m.make_future_dataframe(df, periods=10, n_historic_predictions=5)
+
+
+def test_join_dfs_after_data_drop():
+    log.info("Testing inner join of input df and forecast df")
+    df = pd.DataFrame()
+    df["ds"] = pd.date_range(start="2010-01-01", end="2010-05-01")
+    df["y"] = range(0, len(df["ds"]))
+
+    fcst = pd.DataFrame()
+    fcst["time"] = pd.date_range(start="2009-12-01", end="2010-02-01")
+    fcst["y"] = range(len(fcst["time"]))
+
+    # dfs are not merged into one df
+    fcst, df = df_utils.join_dfs_after_data_drop(fcst, df)
+
+    # merge into one df
+    fcst_merged = df_utils.join_dfs_after_data_drop(fcst, df, merge=True)
 
 
 def test_ffill_in_future_df():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,6 +32,8 @@ def test_save_load():
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,
         learning_rate=LR,
+        n_lags=6,
+        n_forecasts=3,
     )
     _ = m.fit(df, freq="D")
     log.info("testing: save")


### PR DESCRIPTION
**Same changes as in PR #747, but with develop as base branch.**

*added df_utils.drop_missing_from_df() dropping data from df in accordance with drop_nan_after_init() in TimeDataset

*while loop for as long as there are remaining NaN windows after imputation

*find all indices containing NaN in df

*drop NaNs window and lagged values before

*Changed max_lags to n_lags in __handle_missing_data()

*When predicting (only) and dropping nan, only drop values related to lags, not n_forecasts

*Added new helper function: inner join of input df and forecast df to ensure dropped and imputed data points are neglected for model evaluation

*Added kwarg "predict_steps" needed for proper data drop

*predict_steps either is n_forecasts or periods (case of fcst into unknown future)

*predict_steps indicates whether we are predicting in known or unknown future

*Tested edge cases