### PR TITLE
[bugfix] fix re-scaling of multiplicative components in forecast df

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2784,14 +2784,14 @@ class NeuralProphet:
                         multiplicative = True
 
                 # scale additive components
-                if multiplicative == False:
+                if Not multiplicative:
                     components[name] = value * scale_y
                     if "trend" in name:
                         components[name] += shift_y
                 ### scale multiplicative components
-                elif multiplicative == True:
+                if multiplicative:
                     components[name] = (
-                        value * trend * scale_y / (trend * scale_y + shift_y)
+                        value * trend * scale_y
                     )  # need to be divided by unmormalized trend
 
         else:

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2784,15 +2784,13 @@ class NeuralProphet:
                         multiplicative = True
 
                 # scale additive components
-                if Not multiplicative:
+                if not multiplicative:
                     components[name] = value * scale_y
                     if "trend" in name:
                         components[name] += shift_y
                 ### scale multiplicative components
-                if multiplicative:
-                    components[name] = (
-                        value * trend * scale_y
-                    )  # need to be divided by unmormalized trend
+                elif multiplicative:
+                    components[name] = value * trend * scale_y  # output absolute value of respective additive component
 
         else:
             components = None

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2755,28 +2755,48 @@ class NeuralProphet:
         if include_components:
             components = {name: np.concatenate(value) for name, value in component_vectors.items()}
             for name, value in components.items():
-                if "multiplicative" in name:
-                    continue
-                elif "event_" in name:
+                multiplicative = False #Flag for multiplicative components
+                if "trend" in name:
+                    trend = value
+                elif "event_" in name or "events_" in name: #accounts for events and holidays
                     event_name = name.split("_")[1]
                     if self.config_events is not None and event_name in self.config_events:
                         if self.config_events[event_name].mode == "multiplicative":
-                            continue
+                           multiplicative = True
                     elif (
                         self.config_country_holidays is not None
                         and event_name in self.config_country_holidays.holiday_names
                     ):
                         if self.config_country_holidays.mode == "multiplicative":
-                            continue
+                            multiplicative = True
+                    elif "multiplicative" in name:
+                        multiplicative = True
                 elif "season" in name and self.config_season.mode == "multiplicative":
-                    continue
+                    multiplicative = True
+                elif ("future_regressor_" in name or "future_regressors_" in name) and self.config_regressors is not None:
+                    regressor_name = name.split("_")[2]
+                    if self.config_regressors is not None and regressor_name in self.config_regressors:
+                        if self.config_regressors[regressor_name].mode == "multiplicative":
+                           multiplicative = True
+                    elif "multiplicative" in regressor_name:
+                        multiplicative = True
 
                 # scale additive components
-                components[name] = value * scale_y
-                if "trend" in name:
-                    components[name] += shift_y
+                if multiplicative == False:
+                    components[name] = value * scale_y
+                    if "trend" in name:
+                        components[name] += shift_y
+                ### scale multiplicative components
+                elif multiplicative == True:
+                    components[name] = value * trend * scale_y /(trend*scale_y+shift_y) #need to be divided by unmormalized trend
+
         else:
             components = None
+
+        # a = np.allclose(((1+ components['future_regressors_multiplicative']) * components['trend'] + components['future_regressors_additive'] + components['season_weekly']), predicted, atol=1e-08, equal_nan=False)
+        # if a is False:
+        #      raise Exception("does not match")
+
         return dates, predicted, components
 
     def _convert_raw_predictions_to_raw_df(self, dates, predicted, components=None):

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2755,14 +2755,14 @@ class NeuralProphet:
         if include_components:
             components = {name: np.concatenate(value) for name, value in component_vectors.items()}
             for name, value in components.items():
-                multiplicative = False #Flag for multiplicative components
+                multiplicative = False  # Flag for multiplicative components
                 if "trend" in name:
                     trend = value
-                elif "event_" in name or "events_" in name: #accounts for events and holidays
+                elif "event_" in name or "events_" in name:  # accounts for events and holidays
                     event_name = name.split("_")[1]
                     if self.config_events is not None and event_name in self.config_events:
                         if self.config_events[event_name].mode == "multiplicative":
-                           multiplicative = True
+                            multiplicative = True
                     elif (
                         self.config_country_holidays is not None
                         and event_name in self.config_country_holidays.holiday_names
@@ -2773,11 +2773,13 @@ class NeuralProphet:
                         multiplicative = True
                 elif "season" in name and self.config_season.mode == "multiplicative":
                     multiplicative = True
-                elif ("future_regressor_" in name or "future_regressors_" in name) and self.config_regressors is not None:
+                elif (
+                    "future_regressor_" in name or "future_regressors_" in name
+                ) and self.config_regressors is not None:
                     regressor_name = name.split("_")[2]
                     if self.config_regressors is not None and regressor_name in self.config_regressors:
                         if self.config_regressors[regressor_name].mode == "multiplicative":
-                           multiplicative = True
+                            multiplicative = True
                     elif "multiplicative" in regressor_name:
                         multiplicative = True
 
@@ -2788,14 +2790,12 @@ class NeuralProphet:
                         components[name] += shift_y
                 ### scale multiplicative components
                 elif multiplicative == True:
-                    components[name] = value * trend * scale_y /(trend*scale_y+shift_y) #need to be divided by unmormalized trend
+                    components[name] = (
+                        value * trend * scale_y / (trend * scale_y + shift_y)
+                    )  # need to be divided by unmormalized trend
 
         else:
             components = None
-
-        # a = np.allclose(((1+ components['future_regressors_multiplicative']) * components['trend'] + components['future_regressors_additive'] + components['season_weekly']), predicted, atol=1e-08, equal_nan=False)
-        # if a is False:
-        #      raise Exception("does not match")
 
         return dates, predicted, components
 


### PR DESCRIPTION
refer to issue #429 
makes PR #551 unnecessary

**Problem**
Multiplicative components are not output correctly in the forecast df due to being computed incorrectly. 

**Solution**
The multiplicative components are not re-scaled properly. Therefore, the re-scaling of all multiplicative components is added in predict_raw().