### PR TITLE
Corrected all docstrings regarding df dictionaries

### DIFF
--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -243,7 +243,7 @@ def init_data_params(
 
     Parameters
     ----------
-        df : pd.DataFrame, dict (deprecated)
+        df : pd.DataFrame
             data to compute normalization parameters from.
         normalize : str
             Type of normalization to apply to the time series.
@@ -471,7 +471,7 @@ def check_dataframe(df, check_y=True, covariates=None, regressors=None, events=N
 
     Parameters
     ----------
-        df : pd.DataFrame, dict (deprecated)
+        df : pd.DataFrame
             containing column ``ds``
         check_y : bool
             if df must have series values
@@ -663,7 +663,7 @@ def crossvalidation_split_df(
 
     Parameters
     ----------
-        df : pd.DataFrame, dict (deprecated)
+        df : pd.DataFrame
             data
         n_lags : int
             identical to NeuralProphet
@@ -676,7 +676,7 @@ def crossvalidation_split_df(
         fold_overlap_pct : float
             percentage of overlap between the validation folds (default: 0.0)
         global_model_cv_type : str
-            Type of crossvalidation to apply to the dict of time series.
+            Type of crossvalidation to apply to the time series.
 
                 options:
 
@@ -892,8 +892,8 @@ def split_df(df, n_lags, n_forecasts, valid_p=0.2, inputs_overbleed=True, local_
 
     Parameters
     ----------
-        df : pd.DataFrame, dict (deprecated)
-            dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+        df : pd.DataFrame
+            dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
         n_lags : int
             identical to NeuralProphet
         n_forecasts : int
@@ -1273,12 +1273,12 @@ def _infer_frequency(df, freq, min_freq_percentage=0.7):
 
 
 def infer_frequency(df, freq, n_lags, min_freq_percentage=0.7):
-    """Automatically infers frequency of dataframe or dict of dataframes.
+    """Automatically infers frequency of dataframe.
 
     Parameters
     ----------
-        df : pd.DataFrame, dict (deprecated)
-            Dataframe with columns ``ds`` datestamps and ``y`` time series values
+        df : pd.DataFrame
+            Dataframe with columns ``ds`` datestamps and ``y`` time series values, and optionally``ID``
         freq : str
             Data step sizes, i.e. frequency of data recording,
 

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -615,8 +615,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                containing column ``ds``, ``y``, and optionally``ID`` with all data
             freq : str
                 Data step sizes. Frequency of data recording,
 
@@ -685,8 +685,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with data
             decompose : bool
                 whether to add individual components of forecast to the dataframe
             raw : bool
@@ -748,8 +748,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with with holdout data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with with holdout data
         Returns
         -------
             pd.DataFrame
@@ -774,8 +774,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
             freq : str
                 data step sizes. Frequency of data recording,
 
@@ -906,8 +906,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
             freq : str
                 data step sizes. Frequency of data recording,
 
@@ -1070,8 +1070,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
             freq : str
                 data step sizes. Frequency of data recording,
 
@@ -1110,8 +1110,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
             events_df : dict, pd.DataFrame
                 containing column ``ds`` and ``event``
 
@@ -1156,7 +1156,7 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df: pd.DataFrame, dict (deprecated)
+            df: pd.DataFrame
                 History to date. DataFrame containing all columns up to present
             events_df : pd.DataFrame
                 Future event occurrences corresponding to `periods` steps into future.
@@ -1257,8 +1257,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
             quantile : float
                 the quantile in (0, 1) that needs to be predicted
 
@@ -1292,8 +1292,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing columns ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing columns ``ds``, ``y``, and optionally``ID`` with all data
             quantile : float
                 the quantile in (0, 1) that needs to be predicted
 
@@ -1392,7 +1392,7 @@ class NeuralProphet:
 
         Parameters
         ----------
-            fcst : pd.DataFrame, dict (deprecated)
+            fcst : pd.DataFrame
                 output of self.predict.
             df_name : str
                 ID from time series that should be plotted
@@ -1552,7 +1552,7 @@ class NeuralProphet:
 
         Parameters
         ----------
-            fcst : pd.DataFrame, dict (deprecated)
+            fcst : pd.DataFrame
                 output of self.predict.
             df_name : str
                 ID from time series that should be plotted
@@ -1640,7 +1640,7 @@ class NeuralProphet:
 
         Parameters
         ----------
-            fcst : pd.DataFrame, dict (deprecated)
+            fcst : pd.DataFrame
                 output of self.predict
             df_name : str
                 ID from time series that should be plotted
@@ -1802,8 +1802,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` and
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` and
                 normalized columns normalized columns ``ds``, ``y``, ``t``, ``y_scaled``
             predict_mode : bool
                 specifies predict mode
@@ -1965,8 +1965,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
             freq : str
                 data step sizes. Frequency of data recording,
 
@@ -1994,8 +1994,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
             check_y : bool
                 if df must have series values
 
@@ -2078,8 +2078,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
 
         Returns
         -------
@@ -2100,8 +2100,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
 
         Returns
         -------
@@ -2151,8 +2151,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
 
         Returns
         -------
@@ -2307,10 +2307,10 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
-            df_val : pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with validation data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
+            df_val : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with validation data
             progress : str
                 Method of progress display.
 
@@ -2464,8 +2464,8 @@ class NeuralProphet:
 
         Parameters
         ----------
-            df: pd.DataFrame, dict (deprecated)
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+            df: pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
 
         Returns
         -------
@@ -2704,7 +2704,7 @@ class NeuralProphet:
         Parameters
         ----------
             df : pd.DataFrame
-                dataframe or dict of dataframes containing column ``ds``, ``y`` with all data
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
             df_name : str
                 name of the data params from which the current dataframe refers to (only in case of local_normalization)
             include_components : bool

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -20,8 +20,9 @@ class GlobalTimeDataset(Dataset):
 
         Parameters
         ----------
-            df_dict : dict
-                Containing pd.DataFrame time series data
+            df : pd.DataFrame
+                dataframe containing column ``ds``, ``y``, and optionally``ID`` and
+                normalized columns normalized columns ``ds``, ``y``, ``t``, ``y_scaled``
             **kwargs : dict
                 Identical to :meth:`tabularize_univariate_datetime`
         """


### PR DESCRIPTION
Corrects all docstrings in `forecaster.py`, `df_utils.py`, and `time_dataset.py` to talk about ID, not df_dict (completely deprecate dicts)
closes #806 

Next step: Update the code base to remove support for dicts of df as input, see #810 