### PR TITLE
Define documentation build requirements and fix documentation notebook links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ dmypy.json
 # Coverage
 /.coverage
 /coverage.xml
+
+# Docs
+docs/doctrees/
+docs/html/

--- a/docs/source/Live_plot_during_training.nblink
+++ b/docs/source/Live_plot_during_training.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../tutorials/feature-use/Live_plot_during_training.ipynb"
+}

--- a/docs/source/benchmarking.nblink
+++ b/docs/source/benchmarking.nblink
@@ -1,3 +1,0 @@
-{
-    "path": "../../tutorials/feature-use/benchmarking.ipynb"
-}

--- a/docs/source/network_architecture_visualization.nblink
+++ b/docs/source/network_architecture_visualization.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../tutorials/feature-use/network_architecture_visualization.ipynb"
+}

--- a/docs/source/plotly.nblink
+++ b/docs/source/plotly.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../tutorials/feature-use/plotly.ipynb"
+}

--- a/docs/source/uncertainty_estimation_peyton_manning.nblink
+++ b/docs/source/uncertainty_estimation_peyton_manning.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../tutorials/feature-use/uncertainty_estimation_peyton_manning.ipynb"
+}

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,6 @@
+sphinx
+sphinx_fontawesome
+myst_parser
+nbsphinx
+nbsphinx_link
+furo


### PR DESCRIPTION
- Define all required packages for building the documentation as `requirements-docs.txt`
- Fix all links to notebooks in docs (remove missing, add new ones)
- Add docs generated output to gitignore