### PR TITLE
[feature] shared weight nn_net

### DIFF
--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -249,6 +249,8 @@ class TimeNet(nn.Module):
             self.config_events = None
             self.config_holidays = None
 
+        # TODO: Shared weights nn_net
+
         # Autoregression
         self.n_lags = n_lags
         self.num_hidden_layers = num_hidden_layers


### PR DESCRIPTION
Referencing previous PR #616 

**Problem**
Currently, the weights of the separate implementations of the time series components (AR Net, Time Net, Covariates) are updated independently. Hence, they are not updated in dependence on each other.

**Solution** 
Implement a shared weight update and allow the user to choose between shared and independent weights. 