### PR TITLE
868 bug runtime exception during collection when declaring configlaggedregressors

### DIFF
--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import math
 import types
+import typing
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Callable, Optional, Union
@@ -371,7 +372,7 @@ class LaggedRegressor:
                 raise ValueError("regularization must be >= 0")
 
 
-ConfigLaggedRegressors = OrderedDict[str, LaggedRegressor]
+ConfigLaggedRegressors = typing.OrderedDict[str, LaggedRegressor]
 
 
 @dataclass

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -4,10 +4,9 @@ import inspect
 import logging
 import math
 import types
-import typing
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, OrderedDict as OrderedDictType
 
 import numpy as np
 import pandas as pd
@@ -372,7 +371,7 @@ class LaggedRegressor:
                 raise ValueError("regularization must be >= 0")
 
 
-ConfigLaggedRegressors = typing.OrderedDict[str, LaggedRegressor]
+ConfigLaggedRegressors = OrderedDictType[str, LaggedRegressor]
 
 
 @dataclass

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1,6 +1,6 @@
 import time
 from collections import OrderedDict
-from typing import Literal, Optional, Union
+from typing import Optional, Union
 import numpy as np
 import pandas as pd
 
@@ -19,6 +19,12 @@ from neuralprophet.plot_forecast_plotly import plot as plot_plotly, plot_compone
 from neuralprophet.plot_model_parameters_plotly import plot_parameters as plot_parameters_plotly
 from neuralprophet.plot_model_parameters import plot_parameters
 from neuralprophet import metrics
+
+# Ensure compatibility with python 3.7
+try:
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal
 
 log = logging.getLogger("NP.forecaster")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ holidays>=0.11.3.1
 python-dateutil>=2.8.0
 tqdm>=4.50.2
 torch-lr-finder>=0.2.1
+typing_extensions>=4.4.0
 ipywidgets>=7.5.1
 plotly>=4.14.3
 dataclasses>=0.6;python_version<'3.7'


### PR DESCRIPTION
Two problems are fixed with this PR:
- Fix for #868: OrderedDict does behave differently as typing across python version apparently, super weird (see other [issues](https://github.com/python/mypy/issues/6904))
- Fixes missing `typing.Literal` issue with python version 3.7