### PR TITLE
[model] Deep model parameter interpretation

### DIFF
--- a/neuralprophet/plot_model_parameters.py
+++ b/neuralprophet/plot_model_parameters.py
@@ -123,7 +123,9 @@ def plot_parameters(m, quantile, forecast_in_focus=None, weekly_start=0, yearly_
             {
                 "plot_name": "lagged weights",
                 "comp_name": "AR",
-                "weights": m.model.ar_weights.detach().numpy(),
+                "weights": m.model.get_model_input_attributions(net="ar_net", forward_func="auto_regression")
+                .detach()
+                .numpy(),
                 "focus": forecast_in_focus,
             }
         )
@@ -486,10 +488,13 @@ def plot_lagged_weights(weights, comp_name, focus=None, ax=None, figsize=(10, 6)
     lags_range = list(range(1, 1 + n_lags))[::-1]
     if focus is None:
         weights = np.sum(np.abs(weights), axis=0)
+        # TODO: do we always want to normalize?
         weights = weights / np.sum(weights)
-        artists += ax.bar(lags_range, weights, width=1.00, color="#0072B2")
+        artists += ax.bar(lags_range, weights, width=0.80, color="#0072B2")
     else:
         if len(weights.shape) == 2:
+            # TODO: this operation used to hightlight the n'th hidden node of the first layer in a deep network since the ar_weights() functions returns the weights of the first layer.
+            # If a network would have had fewer hidden states than forecasts, this operation would have failed.
             weights = weights[focus - 1, :]
         artists += ax.bar(lags_range, weights, width=0.80, color="#0072B2")
     ax.grid(True, which="major", c="gray", ls="-", lw=1, alpha=0.2)

--- a/neuralprophet/plot_model_parameters.py
+++ b/neuralprophet/plot_model_parameters.py
@@ -495,6 +495,8 @@ def plot_lagged_weights(weights, comp_name, focus=None, ax=None, figsize=(10, 6)
         if len(weights.shape) == 2:
             # TODO: this operation used to hightlight the n'th hidden node of the first layer in a deep network since the ar_weights() functions returns the weights of the first layer.
             # If a network would have had fewer hidden states than forecasts, this operation would have failed.
+            # TODO: check whether this operation returns the correct weight when uncertainty is activated in a deep network.
+            # Would assume that the focus does not account for the uncertainty dimension. Expected: focus*len(quantiles)-1
             weights = weights[focus - 1, :]
         artists += ax.bar(lags_range, weights, width=0.80, color="#0072B2")
     ax.grid(True, which="major", c="gray", ls="-", lw=1, alpha=0.2)

--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 import logging
 from neuralprophet import configure
+from neuralprophet.utils_torch import interprete_model
 from neuralprophet.utils import (
     config_season_to_model_dims,
     config_regressors_to_model_dims,
@@ -402,6 +403,26 @@ class TimeNet(nn.Module):
             regressor_params = self.regressor_params["multiplicative"]
 
         return regressor_params[:, index : (index + 1)]
+
+    def get_model_input_attributions(self, net: str = "ar_net", forward_func: str = "auto_regression"):
+        """
+        Returns model input attributions for a given network and forward function.
+
+        Parameters
+        ----------
+            net : str
+                Name of the network for which input attributions are to be computed.
+
+            forward_func : str
+                Name of the forward function for which input attributions are to be computed.
+
+        Returns
+        -------
+            torch.Tensor
+                Input attributions for the given network and forward function.
+        """
+        attributions = interprete_model(self, net, forward_func)
+        return attributions
 
     def _compute_quantile_forecasts_from_diffs(self, diffs, predict_mode=False):
         """


### PR DESCRIPTION
**Status quo**
When the NN uses hidden layers, only the model weights of the first layer are interpreted when using the `plot_parameters()` function. This could be misleading to a user who wants to interprete the model.

> Note: in some places this lead to wrong results in the plots, eg. when a user set `highlight_nth_forecast` in `plot_parameters()`, the weights of the lags w.r.t the n'th hidden layer is returned (since the weights are `input x hidden1`). If the shape of the hidden layer does not match the shape of the output, this also leads to runtime issues.

**Change**
Instead of using the weights of the first layer, we use a model attribution method to calculate the attributions of the lags w.r.t. each forecast. We use pytorch's captum library for saliency calculation.