### PR TITLE
[bugfix] Added repository to metrics artifact download

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Download metrics from main
         uses: dawidd6/action-download-artifact@v2
         with:
+          repo: ourownstory/neural_prophet
           branch: main
           name: metrics
           path: tests/metrics-main/


### PR DESCRIPTION
If a new pr is opened from a branch on a fork, the metrics job seems to search for the metrics on the main branch of the respective fork. As this is not intended, the repository to load the artifacts from is now specified.