### PR TITLE
895 test documentation build and make any warnings fail the test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
           pip install --upgrade -r requirements.txt # install all requirements, otherwise the code docs don't build
           pip install --upgrade -r requirements-docs.txt
       - name: Build with Sphinx
-        run: sphinx-build docs/source _site
+        run: sphinx-build -W docs/source _site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,17 @@ jobs:
           files: ./coverage.xml
           name: Coverage Report with codecov overview
           verbose: true
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pandoc
+        uses: r-lib/actions/setup-pandoc@v1
+      - name: Setup Requirements
+        run: |
+          pip install --upgrade -r requirements.txt # install all requirements, otherwise the code docs don't build
+          pip install --upgrade -r requirements-docs.txt
+      - name: Build with Sphinx
+        run: sphinx-build docs/source _site


### PR DESCRIPTION
Close #895 

- The errors withing the docstring (autodoc) module are only propagated as warnings, therefore we let sphnix-build fail on any warning