### PR TITLE
[lightning] remove rich progress bar

### DIFF
--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -813,18 +813,6 @@ def configure_trainer(
         )
         config["callbacks"].append(early_stop_callback)
 
-    # Swap the tqdm progress bar for the rich progress bar
-    progress_bar = pl.callbacks.RichProgressBar(
-        leave=False,
-        refresh_rate=config_train.batch_size,
-        theme=pl.callbacks.progress.rich_progress.RichProgressBarTheme(
-            progress_bar="#2d92ff",  # set custom NeuralProphet color
-            progress_bar_finished="green1",
-            progress_bar_pulse="#2d92ff",
-        ),
-    )
-    config["callbacks"].append(progress_bar)
-
     config["num_sanity_val_steps"] = 0
 
     return pl.Trainer(**config)


### PR DESCRIPTION
The rich progress bar seemed to cause significant overhead in the training loop, pushing the training time to 5.2 minutes for 89 epochs on peyton manning data. Training time before Lightning was ~2.5 min.

When deactivating all logging in Lightning, the training time could be pushed to 55 seconds. [Reference](https://towardsdatascience.com/pytorch-lightning-vs-deepspeed-vs-fsdp-vs-ffcv-vs-e0d6b2a95719)

When adding all checkpointing functionality back and switching to the default tqdm progress bar, the training takes 1.32 minutes (which @Kevin-Chen0 and I find acceptable).

This pr removes the custom progress bar.