### PR TITLE
Added plot param of the NeuralProphet fit() and uncomment test_progress_display in test_integration.py.

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -635,7 +635,7 @@ class NeuralProphet:
         self.config_season.append(name=name, period=period, resolution=fourier_order, arg="custom")
         return self
 
-    def fit(self, df, freq="auto", validation_df=None, progress="bar", minimal=False, continue_training=False):
+    def fit(self, df, freq="auto", validation_df=None, progress="bar", minimal=False, continue_training=False, plot=True):
         """Train, and potentially evaluate model.
 
         Training/validation metrics may be distorted in case of auto-regression,
@@ -657,6 +657,8 @@ class NeuralProphet:
                 whether to train without any printouts or metrics collection
             continue_training : bool
                 whether to continue training from the last checkpoint
+            plot : bool
+                where to show the progress plot or not
 
         Returns
         -------
@@ -725,7 +727,8 @@ class NeuralProphet:
                 _ = plt.plot(metrics_df[["Loss"]])
             else:
                 _ = plt.plot(metrics_df[["Loss", "Loss_val"]])
-            plt.show()
+            if plot:
+                plt.show()
 
         self.fitted = True
         return metrics_df

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -635,7 +635,9 @@ class NeuralProphet:
         self.config_season.append(name=name, period=period, resolution=fourier_order, arg="custom")
         return self
 
-    def fit(self, df, freq="auto", validation_df=None, progress="bar", minimal=False, continue_training=False, plot=True):
+    def fit(
+        self, df, freq="auto", validation_df=None, progress="bar", minimal=False, continue_training=False, plot=True
+    ):
         """Train, and potentially evaluate model.
 
         Training/validation metrics may be distorted in case of auto-regression,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1433,7 +1433,6 @@ def test_metrics():
     forecast = m2.predict(df)
 
 
-"""
 def test_progress_display():
     log.info("testing: Progress Display")
     df = pd.read_csv(AIR_FILE, nrows=100)
@@ -1445,8 +1444,7 @@ def test_progress_display():
             batch_size=BATCH_SIZE,
             learning_rate=LR,
         )
-        metrics_df = m.fit(df, progress=progress)
-"""
+        metrics_df = m.fit(df, progress=progress, plot=PLOT)
 
 
 def test_n_lags_for_regressors():


### PR DESCRIPTION
Added plot parameter in the NeuralProphet fit method that can toggle whether `plt.show()` is executed or not. Therefore, this param can be set to `False` for unit testing. This will prevent `test_progress_display` from hanging the PR tests, as seen Issue [#928](https://github.com/ourownstory/neural_prophet/issues/928).