### PR TITLE
refactored test failure

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 import numpy as np
 import pandas as pd
 import torch
-from matplotlib import pyplot as plt
+import matplotlib
 from torch.utils.data import DataLoader
 
 from neuralprophet import configure, df_utils, metrics, time_dataset, time_net, utils
@@ -635,9 +635,7 @@ class NeuralProphet:
         self.config_season.append(name=name, period=period, resolution=fourier_order, arg="custom")
         return self
 
-    def fit(
-        self, df, freq="auto", validation_df=None, progress="bar", minimal=False, continue_training=False, plot=True
-    ):
+    def fit(self, df, freq="auto", validation_df=None, progress="bar", minimal=False, continue_training=False):
         """Train, and potentially evaluate model.
 
         Training/validation metrics may be distorted in case of auto-regression,
@@ -659,8 +657,6 @@ class NeuralProphet:
                 whether to train without any printouts or metrics collection
             continue_training : bool
                 whether to continue training from the last checkpoint
-            plot : bool
-                where to show the progress plot or not
 
         Returns
         -------
@@ -723,14 +719,15 @@ class NeuralProphet:
             metrics_df = self._train(df, df_val=df_val, minimal=minimal, continue_training=continue_training)
 
         # Show training plot
-        # TODO: outsource into separate function
         if progress == "plot":
             if validation_df is None:
-                _ = plt.plot(metrics_df[["Loss"]])
+                fig = matplotlib.pyplot.plot(metrics_df[["Loss"]])
             else:
-                _ = plt.plot(metrics_df[["Loss", "Loss_val"]])
-            if plot:
-                plt.show()
+                fig = matplotlib.pyplot.plot(metrics_df[["Loss", "Loss_val"]])
+            # Only display the plot if the session is interactive, eg. do not show in github actions since it
+            # causes an error in the Windows and MacOS environment
+            if matplotlib.is_interactive():
+                fig.show()
 
         self.fitted = True
         return metrics_df

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -4,10 +4,10 @@ import time
 from collections import OrderedDict
 from typing import Optional, Union
 
+import matplotlib
 import numpy as np
 import pandas as pd
 import torch
-import matplotlib
 from torch.utils.data import DataLoader
 
 from neuralprophet import configure, df_utils, metrics, time_dataset, time_net, utils

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1444,7 +1444,7 @@ def test_progress_display():
             batch_size=BATCH_SIZE,
             learning_rate=LR,
         )
-        metrics_df = m.fit(df, progress=progress, plot=PLOT)
+        metrics_df = m.fit(df, progress=progress)
 
 
 def test_n_lags_for_regressors():


### PR DESCRIPTION
I found a more elegant way on how we can avoide the pytest with .show to fail.
It seems like the cause of the issue is that the python session on the gh action workers is non-interactive, which causes the `.show()` call to crash the session. This can be avoided by calling `.isinteractive()` on the matplotlib session.

Let me know what you think.

References:
- https://stackoverflow.com/questions/29620884/how-to-put-python-3-4-matplotlib-in-non-interactive-mode
- https://gist.github.com/matthewfeickert/84245837f09673b2e7afea929c016904