### PR TITLE
[tests] Add tests for configure

### DIFF
--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,4 +1,5 @@
 import pytest
+
 from neuralprophet.configure import Train
 
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,24 +1,29 @@
 from neuralprophet.configure import Train
 
 
-config_train_defaults = {}
-config_train_defaults.setdefault("quantiles", None)
-config_train_defaults.setdefault("learning_rate", None)
-config_train_defaults.setdefault("epochs", None)
-config_train_defaults.setdefault("batch_size", None)
-config_train_defaults.setdefault("loss_func", "Huber")
-config_train_defaults.setdefault("optimizer", "AdamW")
+def generate_config_train_params(overrides):
+    config_train_params = {
+        "quantiles": None,
+        "learning_rate": None,
+        "epochs": None,
+        "batch_size": None,
+        "loss_func": "Huber",
+        "optimizer": "AdamW",
+    }
+    for key, value in overrides.items():
+        config_train_params[key] = value
+    return config_train_params
 
 
-def test_config_training_quantiles_initialization_none():
-    params = config_train_defaults.copy()
-    params["quantiles"] = None
-    train = Train(**params)
-    assert train.quantiles == [0.5]
+def test_config_training_quantiles():
+    checks = [
+        ({}, [0.5]),
+        ({"quantiles": None}, [0.5]),
+        ({"quantiles": []}, [0.5]),
+        ({"quantiles": [0.2]}, [0.5, 0.2]),
+    ]
 
-
-def test_config_training_quantiles_initialization_empty():
-    params = config_train_defaults.copy()
-    params["quantiles"] = []
-    train = Train(**params)
-    assert train.quantiles == [0.5]
+    for overrides, expected in checks:
+        config_train_params = generate_config_train_params(overrides)
+        config = Train(**config_train_params)
+        assert config.quantiles == expected

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,0 +1,21 @@
+from neuralprophet.configure import Train
+
+
+config_train_defaults = {
+    "quantiles": None,
+    "learning_rate": None,
+    "epochs": None,
+    "batch_size": None,
+    "loss_func": "Huber",
+    "optimizer": "AdamW",
+}
+
+
+def test_config_training_quantiles_initialization_none():
+    train = Train(**config_train_defaults, quantiles=None)
+    assert train.quantiles == [0.5]
+
+
+def test_config_training_quantiles_initialization_empty():
+    train = Train(**config_train_defaults, quantiles=[])
+    assert train.quantiles == [0.5]

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,7 +1,8 @@
+import pytest
 from neuralprophet.configure import Train
 
 
-def generate_config_train_params(overrides):
+def generate_config_train_params(overrides={}):
     config_train_params = {
         "quantiles": None,
         "learning_rate": None,
@@ -29,3 +30,19 @@ def test_config_training_quantiles():
         config_train_params = generate_config_train_params(overrides)
         config = Train(**config_train_params)
         assert config.quantiles == expected
+
+
+def test_config_training_quantiles_error_invalid_type():
+    config_train_params = generate_config_train_params()
+    config_train_params["quantiles"] = "hello world"
+    with pytest.raises(AssertionError) as err:
+        Train(**config_train_params)
+    assert str(err.value) == "Quantiles must be in a list format, not None or scalar."
+
+
+def test_config_training_quantiles_error_invalid_scale():
+    config_train_params = generate_config_train_params()
+    config_train_params["quantiles"] = [-1]
+    with pytest.raises(Exception) as err:
+        Train(**config_train_params)
+    assert str(err.value) == "The quantiles specified need to be floats in-between (0, 1)."

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,21 +1,24 @@
 from neuralprophet.configure import Train
 
 
-config_train_defaults = {
-    "quantiles": None,
-    "learning_rate": None,
-    "epochs": None,
-    "batch_size": None,
-    "loss_func": "Huber",
-    "optimizer": "AdamW",
-}
+config_train_defaults = {}
+config_train_defaults.setdefault("quantiles", None)
+config_train_defaults.setdefault("learning_rate", None)
+config_train_defaults.setdefault("epochs", None)
+config_train_defaults.setdefault("batch_size", None)
+config_train_defaults.setdefault("loss_func", "Huber")
+config_train_defaults.setdefault("optimizer", "AdamW")
 
 
 def test_config_training_quantiles_initialization_none():
-    train = Train(**config_train_defaults, quantiles=None)
+    params = config_train_defaults.copy()
+    params["quantiles"] = None
+    train = Train(**params)
     assert train.quantiles == [0.5]
 
 
 def test_config_training_quantiles_initialization_empty():
-    train = Train(**config_train_defaults, quantiles=[])
+    params = config_train_defaults.copy()
+    params["quantiles"] = []
+    train = Train(**params)
     assert train.quantiles == [0.5]

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -21,6 +21,8 @@ def test_config_training_quantiles():
         ({"quantiles": None}, [0.5]),
         ({"quantiles": []}, [0.5]),
         ({"quantiles": [0.2]}, [0.5, 0.2]),
+        ({"quantiles": [0.2, 0.8]}, [0.5, 0.2, 0.8]),
+        ({"quantiles": [0.5, 0.8]}, [0.5, 0.8]),
     ]
 
     for overrides, expected in checks:


### PR DESCRIPTION
Basic tests for training config quantiles initialization.

Motivation: if we refactor the handling of configuration options and their internals it is good to have some test cases to ensure we do not break anything. This is a starting point for more work in this direction and to provide the template for other test cases people can replicate if they work on some of the configuration objects and want some safety net :)