### PR TITLE
Follow-up tensors on wrong device

### DIFF
--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -268,9 +268,7 @@ class TimeNet(pl.LightningModule):
                 # https://pytorch-lightning.readthedocs.io/en/stable/starter/converting.html#remove-any-cuda-or-to-device-calls
                 self.register_buffer(
                     "trend_changepoints_t",
-                    torch.tensor(
-                        self.config_trend.changepoints, requires_grad=False, dtype=torch.float, device=self.device
-                    ),
+                    torch.tensor(self.config_trend.changepoints, requires_grad=False, dtype=torch.float),
                 )
 
                 # Trend Deltas parameters

--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -935,9 +935,8 @@ class TimeNet(pl.LightningModule):
             torch.Tensor
                 Forecast of dims (batch, n_forecasts, no_quantiles)
         """
-        # Turnaround to avoid issues when the meta argument is None in trend_global_local = 'local' configuration
-        # I'm repeating code here, config_season being None brings problems.
-        if self.meta_used_in_model:
+        # Turnaround to avoid issues when the meta argument is None and meta_used_in_model
+        if meta is None and self.meta_used_in_model:
             name_id_dummy = self.id_list[0]
             meta = OrderedDict()
             meta["df_name"] = [name_id_dummy for _ in range(inputs["time"].shape[0])]


### PR DESCRIPTION
## :microscope: Background

As pointed out in #1002, some tensors have remained on the CPU when training with a GPU. This has previously been adressed #1010, it seems like some tensors remained on the wrong device.

## :crystal_ball: Key changes

- Moved all tensors to the correct device (checked all usages of `torch.zeros`, `torch.ones`, `torch.tensor` via strg+F)
- Added the usage of `self. meta_used_in_model` in the forward function

## :clipboard: Review Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
