### PR TITLE
Normalize training speed metric

### DIFF
--- a/tests/test_model_performance.py
+++ b/tests/test_model_performance.py
@@ -33,7 +33,7 @@ def get_system_speed():
     benchmarks = np.array([])
     for a in range(0, repeats):
         start = time.time()
-        for i in range(0, 50):
+        for i in range(0, 1000):
             for x in range(1, 1000):
                 3.141592 * 2**x
             for x in range(1, 1000):

--- a/tests/test_model_performance.py
+++ b/tests/test_model_performance.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import time
 
+import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import pytest
@@ -25,6 +26,32 @@ YOS_FILE = os.path.join(DATA_DIR, "yosemite_temps.csv")
 
 # Important to set seed for reproducibility
 set_random_seed(42)
+
+
+def get_system_speed():
+    repeats = 5
+    benchmarks = np.array([])
+    for a in range(0, repeats):
+        start = time.time()
+        for i in range(0, 50):
+            for x in range(1, 1000):
+                3.141592 * 2**x
+            for x in range(1, 1000):
+                float(x) / 3.141592
+            for x in range(1, 1000):
+                float(3.141592) / x
+
+        end = time.time()
+        duration = end - start
+        duration = round(duration, 3)
+        benchmarks = np.append(benchmarks, duration)
+
+    log.info(f"System speed: {round(np.mean(benchmarks), 5)}s")
+    log.info(f"Standart deviation: {round(np.std(benchmarks), 5)}s")
+    return benchmarks.mean(), benchmarks.std()
+
+
+system_speed, std = get_system_speed()
 
 
 def create_metrics_plot(metrics):
@@ -99,6 +126,8 @@ def test_PeytonManning():
 
     accuracy_metrics = metrics.to_dict("records")[-1]
     accuracy_metrics["time"] = round(end - start, 2)
+    accuracy_metrics["system_performance"] = round(system_speed, 5)
+    accuracy_metrics["system_std"] = round(std, 5)
     with open(os.path.join(DIR, "tests", "metrics", "PeytonManning.json"), "w") as outfile:
         json.dump(accuracy_metrics, outfile)
 
@@ -122,6 +151,8 @@ def test_YosemiteTemps():
 
     accuracy_metrics = metrics.to_dict("records")[-1]
     accuracy_metrics["time"] = round(end - start, 2)
+    accuracy_metrics["system_performance"] = round(system_speed, 5)
+    accuracy_metrics["system_std"] = round(std, 5)
     with open(os.path.join(DIR, "tests", "metrics", "YosemiteTemps.json"), "w") as outfile:
         json.dump(accuracy_metrics, outfile)
 
@@ -138,6 +169,8 @@ def test_AirPassengers():
 
     accuracy_metrics = metrics.to_dict("records")[-1]
     accuracy_metrics["time"] = round(end - start, 2)
+    accuracy_metrics["system_performance"] = round(system_speed, 5)
+    accuracy_metrics["system_std"] = round(std, 5)
     with open(os.path.join(DIR, "tests", "metrics", "AirPassengers.json"), "w") as outfile:
         json.dump(accuracy_metrics, outfile)
 


### PR DESCRIPTION
## :microscope: Background

- The training time across pull requests is often off by a lot although the code did not change significantly

## :crystal_ball: Key changes

- Measure the performance of the CPU by performing pi calculation operations. Use the metrics to normalize the training time across different system requirements.

## :clipboard: Review Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
