### PR TITLE
Normalize training time metric

### DIFF
--- a/tests/metrics/compareMetrics.py
+++ b/tests/metrics/compareMetrics.py
@@ -51,7 +51,7 @@ for f in metrics_files:
         df["diff"] = "-"
         df[" "] = ""
         df = df.round(4)
-    
+
     # Remove unused metrics
     df = df[~df["Metric"].isin(["epoch", "RegLoss", "RegLoss_val", "system_performance", "system_std"])]
     df["Benchmark"] = f.split(".")[0]

--- a/tests/metrics/compareMetrics.py
+++ b/tests/metrics/compareMetrics.py
@@ -51,7 +51,9 @@ for f in metrics_files:
         df["diff"] = "-"
         df[" "] = ""
         df = df.round(4)
-    df = df[~df["Metric"].isin(["epoch", "RegLoss", "RegLoss", "RegLoss_val", "RegLoss", "system_performance", "system_std"])]
+    
+    # Remove unused metrics
+    df = df[~df["Metric"].isin(["epoch", "RegLoss", "RegLoss_val", "system_performance", "system_std"])]
     df["Benchmark"] = f.split(".")[0]
     df = df[["Benchmark", "Metric", "main", "current", "diff", " "]]
     all_metrics = pd.concat([all_metrics, df])

--- a/tests/metrics/compareMetrics.py
+++ b/tests/metrics/compareMetrics.py
@@ -27,11 +27,19 @@ for f in metrics_files:
 
     if main is not None:
         df = pd.merge(current, main, on=["Metric"], how="left")
+
+        # Adjust the runtime metrics
+        time = df.loc[df["Metric"] == "time"]
+        performance = df.loc[df["Metric"] == "system_performance"]
+        adjusted_performance = time["main"].values[0] / performance["main"].values[0] * performance["current"].values[0]
+        df.loc[df["Metric"] == "time", "main"] = adjusted_performance
+
         df["diff"] = ((df["main"] - df["current"]) / df["main"]) * 100 * -1
+
         df = df.round(5)
         df[" "] = np.select(
-            condlist=[(df["diff"] >= 3.0), (df["diff"] >= 7.0)],
-            choicelist=[":warning:", ":x:"],
+            condlist=[(df["diff"] >= 7.0), (df["diff"] >= 3.0), (df["diff"] <= -5.0)],
+            choicelist=[":x:", ":warning:", ":tada:"],
             default=":white_check_mark:",
         )
         df["diff"] = df["diff"].fillna(0)

--- a/tests/metrics/compareMetrics.py
+++ b/tests/metrics/compareMetrics.py
@@ -51,7 +51,7 @@ for f in metrics_files:
         df["diff"] = "-"
         df[" "] = ""
         df = df.round(4)
-
+    df = df[~df["Metric"].isin(["epoch", "RegLoss", "RegLoss", "RegLoss_val", "RegLoss", "system_performance", "system_std"])]
     df["Benchmark"] = f.split(".")[0]
     df = df[["Benchmark", "Metric", "main", "current", "diff", " "]]
     all_metrics = pd.concat([all_metrics, df])


### PR DESCRIPTION
## :microscope: Background

- The training time metric depends on the system performance, but github action workers have varying system specifications.

## :crystal_ball: Key changes

- This pr normalizes the training time based on the currently available system specs.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
