### PR TITLE
Progress bar in minimal mode is default instead of deactivated

### DIFF
--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -828,7 +828,6 @@ def configure_trainer(
         prog_bar_callback = ProgressBar(refresh_rate=num_batches_per_epoch, epochs=config_train.epochs)
         callbacks.append(prog_bar_callback)
     else:
-        config["progress_bar_refresh_rate"] = 0
         config["enable_progress_bar"] = False
 
     # Early stopping monitor

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -827,6 +827,9 @@ def configure_trainer(
     if progress_bar_enabled:
         prog_bar_callback = ProgressBar(refresh_rate=num_batches_per_epoch, epochs=config_train.epochs)
         callbacks.append(prog_bar_callback)
+    else:
+        config["progress_bar_refresh_rate"] = 0
+        config["enable_progress_bar"] = False
 
     # Early stopping monitor
     if early_stopping:


### PR DESCRIPTION
## :microscope: Background

In case the progress bar is disabled via `progress=False` or `minimal=True`, no progress bar should be shown. However, in the current release the default Lightning progress bar is displayed which makes the training very slow.

Closes #1054 

## :crystal_ball: Key changes

- Sets the `enable_progress_bar` parameter to False on the Lightning Trainer.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
