### PR TITLE
[Fix] Fixed error in plot loss

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -823,7 +823,7 @@ class NeuralProphet:
             # Only display the plot if the session is interactive, eg. do not show in github actions since it
             # causes an error in the Windows and MacOS environment
             if matplotlib.is_interactive():
-                fig.show()
+                fig
 
         self.fitted = True
         return metrics_df


### PR DESCRIPTION
## :microscope: Background

- When plotting the loss of the training using `progress="plot"`, an error is raised.

## :crystal_ball: Key changes

- This PR fixes this by removing the .show() aftter the figure. We figured out that matplotlib calls .show() internally, so the figure is till shown in notebooks.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
