### PR TITLE
Improve plotly interactive rendering performance 

### DIFF
--- a/neuralprophet/plot_forecast_plotly.py
+++ b/neuralprophet/plot_forecast_plotly.py
@@ -12,6 +12,7 @@ try:
     import plotly.express as px
     import plotly.graph_objs as go
     from plotly.subplots import make_subplots
+    from plotly_resampler import register_plotly_resampler
 except ImportError:
     log.error("Importing plotly failed. Interactive plots will not work.")
 
@@ -39,6 +40,7 @@ layout_args = {
     "title": dict(font=dict(size=12)),
     "hovermode": "x unified",
 }
+register_plotly_resampler(mode="auto")
 
 
 def plot(fcst, quantiles, xlabel="ds", ylabel="y", highlight_forecast=None, line_per_origin=False, figsize=(700, 210)):
@@ -209,7 +211,6 @@ def plot(fcst, quantiles, xlabel="ds", ylabel="y", highlight_forecast=None, line
         **layout_args,
     )
     fig = go.Figure(data=data, layout=layout)
-
     return fig
 
 
@@ -301,7 +302,7 @@ def plot_components(m, fcst, plot_configuration, df_name="__df__", one_period_pe
         yaxis.update(trace_object["yaxis"])
         yaxis.update(**yaxis_args)
         for trace in trace_object["traces"]:
-            fig.add_trace(trace, j + 1, 1)
+            fig.add_trace(trace, row=j + 1, col=1)  # adapt var name to plotly-resampler
         fig.update_layout(legend={"y": 0.1, "traceorder": "reversed"})
 
     # Reset multiplicative axes labels after tight_layout adjustment

--- a/tests/temp_plotly_performance.ipynb
+++ b/tests/temp_plotly_performance.ipynb
@@ -1,0 +1,852 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Plotly Performance - Investigation**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Instructions:\n",
+    "- install plotly-resample: `pip install plotly-resampler` (https://github.com/predict-idlab/plotly-resampler)\n",
+    "- execute this notebook: once on your local environment AND once in your online environment (e.g. jupyterlab)\n",
+    "- Have a look at the execution times of Test 1 - 4 and\n",
+    "fill your infos into this first table: https://docs.google.com/document/d/1ruplgpMVA-rjwkSSvZvYMfnCNkBiTAX6A8i5impuKZE/edit?usp=sharing\n",
+    "- additionally, execute the `temp_plotly_performance.py` and fill your info\n",
+    "in the second table of the file linked above\n",
+    "\n",
+    "Thank you!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#####  Import libraries and extract data from github\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "import pandas as pd\n",
+    "import plotly\n",
+    "\n",
+    "from neuralprophet import set_log_level\n",
+    "from plotly_resampler import register_plotly_resampler\n",
+    "# from plotly_resampler.figure_resampler import display\n",
+    "# from IPython.display import display\n",
+    "import plotly.io as pio\n",
+    "import time\n",
+    "import psutil\n",
+    "\n",
+    "set_log_level(\"ERROR\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#####  Get number of CPUs in the system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Get the number of CPUs in the system\n",
+    "num_cores = os.cpu_count()\n",
+    "\n",
+    "# Print the number of used cores\n",
+    "print(f'Number of used cores: {num_cores}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Get plotly default renderer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"plotly default renderer:\", pio.renderers.default)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Prepare test data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "data_location = \"https://raw.githubusercontent.com/ourownstory/neuralprophet-data/main/datasets/\"\n",
+    "file = \"energy/SF_hospital_load.csv\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "data_df = pd.read_csv(data_location + file)\n",
+    "data_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Create df with 2x number of rows\n",
+    "rng_2x = pd.date_range(start='2015-01-01 01:00:00', freq='H', periods=2*8760)\n",
+    "y_2x = pd.concat([data_df['y'], data_df['y']], ignore_index=True)\n",
+    "data_df_2x = pd.DataFrame({'ds': rng_2x, 'y': y_2x})\n",
+    "data_df_2x.tail(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Create df with 10x number of rows*\n",
+    "rng_10x = pd.date_range(start='2015-01-01 01:00:00', freq='H', periods=10*8760)\n",
+    "y_10x = pd.concat([data_df_2x['y'], data_df_2x['y'], data_df_2x['y'], data_df_2x['y'], data_df_2x['y']], ignore_index=True)\n",
+    "data_df_10x = pd.DataFrame({'ds': rng_10x, 'y': y_10x})\n",
+    "data_df_10x.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Define, fit, and predict models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "quantile_lo, quantile_hi = 0.05, 0.95\n",
+    "quantiles = [quantile_lo, quantile_hi]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from neuralprophet import NeuralProphet\n",
+    "\n",
+    "m = NeuralProphet(\n",
+    "    epochs=1,\n",
+    "    batch_size=128,\n",
+    "    learning_rate=1.0,\n",
+    "    n_forecasts=7,\n",
+    "    n_lags=14,\n",
+    "    quantiles=quantiles\n",
+    ")\n",
+    "\n",
+    "m2x = NeuralProphet(\n",
+    "    epochs=1,\n",
+    "    batch_size=128,\n",
+    "    learning_rate=1.0,\n",
+    "    n_forecasts=7,\n",
+    "    n_lags=14,\n",
+    "    quantiles=quantiles\n",
+    ")\n",
+    "\n",
+    "m10x = NeuralProphet(\n",
+    "    epochs=1,\n",
+    "    batch_size=128,\n",
+    "    learning_rate=1.0,\n",
+    "    n_forecasts=7,\n",
+    "    n_lags=14,\n",
+    "    quantiles=quantiles\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "metrics = m.fit(data_df, freq=\"H\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "metrics2x = m2x.fit(data_df_2x, freq=\"H\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "metrics10x = m10x.fit(data_df_10x, freq=\"H\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "forecast = m.predict(data_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "forecast2x= m2x.predict(data_df_2x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "forecast10x = m10x.predict(data_df_10x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# register plotly-resampler in 'auto' mode\n",
+    "register_plotly_resampler(mode='auto')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# get the start time\n",
+    "st = time.time()\n",
+    "\n",
+    "fig1 = m.highlight_nth_step_ahead_of_each_forecast(1).plot(\n",
+    "    forecast, plotting_backend='plotly'\n",
+    ").show()\n",
+    "\n",
+    "# get the end time\n",
+    "et = time.time()\n",
+    "elapsed_time = et - st\n",
+    "print('Execution time:', elapsed_time, 'seconds')\n",
+    "print('RAM memory % used:', psutil.virtual_memory()[2])\n",
+    "print('RAM Used (GB):', psutil.virtual_memory()[3]/1000000000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# get the start time\n",
+    "st = time.time()\n",
+    "\n",
+    "fig2 = m10x.highlight_nth_step_ahead_of_each_forecast(1).plot(\n",
+    "    forecast10x, plotting_backend='plotly'\n",
+    ").show()\n",
+    "\n",
+    "# get the end time\n",
+    "et = time.time()\n",
+    "elapsed_time = et - st\n",
+    "print('Execution time:', elapsed_time, 'seconds')\n",
+    "print('RAM memory % used:', psutil.virtual_memory()[2])\n",
+    "print('RAM Used (GB):', psutil.virtual_memory()[3]/1000000000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### Test 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# get the start time\n",
+    "st = time.time()\n",
+    "\n",
+    "fig3 = m.highlight_nth_step_ahead_of_each_forecast(1).plot(\n",
+    "    forecast, plotting_backend='matplotlib'\n",
+    ").show()\n",
+    "\n",
+    "# get the end time\n",
+    "et = time.time()\n",
+    "elapsed_time = et - st\n",
+    "print('Execution time:', elapsed_time, 'seconds')\n",
+    "print('RAM memory % used:', psutil.virtual_memory()[2])\n",
+    "print('RAM Used (GB):', psutil.virtual_memory()[3]/1000000000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# get the start time\n",
+    "st = time.time()\n",
+    "\n",
+    "fig4 = m10x.highlight_nth_step_ahead_of_each_forecast(1).plot(\n",
+    "    forecast10x, plotting_backend='matplotlib'\n",
+    ").show()\n",
+    "\n",
+    "# get the end time\n",
+    "et = time.time()\n",
+    "elapsed_time = et - st\n",
+    "print('Execution time:', elapsed_time, 'seconds')\n",
+    "print('RAM memory % used:', psutil.virtual_memory()[2])\n",
+    "print('RAM Used (GB):', psutil.virtual_memory()[3]/1000000000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "energy_data_example.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "PyCharm (neural_prophet)",
+   "language": "python",
+   "name": "pycharm-ad229a23"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "a9896633dd2687027a97d37c5dc67af73c090796eacc50847f77e025856fff9f"
+   }
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "24bf564f55644476911a6cf004a395e7": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_aab682cd3df24821a80331720f7c24e5",
+      "placeholder": "​",
+      "style": "IPY_MODEL_f35fc9cbd82c4187a4cdc08c3ac26998",
+      "value": " 264/297 [00:04&lt;00:00, 59.93it/s]"
+     }
+    },
+    "2d8235496ec642af8192f52d9f2692b1": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_8a192ccc35e94e9f8be85898ed583e2c",
+      "placeholder": "​",
+      "style": "IPY_MODEL_87c170d1e00742a29e7f797e98c49cc2",
+      "value": " 89%"
+     }
+    },
+    "4ac0917121f8498698e087259b787dcf": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_2d8235496ec642af8192f52d9f2692b1",
+       "IPY_MODEL_c94a8ae41b994c55a96ad44806b0f1c7",
+       "IPY_MODEL_24bf564f55644476911a6cf004a395e7"
+      ],
+      "layout": "IPY_MODEL_94108fe9090f47c7ba2216479e0d3fac"
+     }
+    },
+    "87c170d1e00742a29e7f797e98c49cc2": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "8a192ccc35e94e9f8be85898ed583e2c": {
+     "model_module": "@jupyter-widgets/base",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "94108fe9090f47c7ba2216479e0d3fac": {
+     "model_module": "@jupyter-widgets/base",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "9467345334da47a8beadc770feef952a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "aab682cd3df24821a80331720f7c24e5": {
+     "model_module": "@jupyter-widgets/base",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "c94a8ae41b994c55a96ad44806b0f1c7": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "danger",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_dc468cd35d2b4f0e8eb287689ac15412",
+      "max": 297,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_9467345334da47a8beadc770feef952a",
+      "value": 264
+     }
+    },
+    "dc468cd35d2b4f0e8eb287689ac15412": {
+     "model_module": "@jupyter-widgets/base",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "f35fc9cbd82c4187a4cdc08c3ac26998": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/temp_plotly_performance.py
+++ b/tests/temp_plotly_performance.py
@@ -1,0 +1,89 @@
+import time
+import pandas as pd
+import psutil
+from neuralprophet import NeuralProphet
+
+
+data_location = "https://raw.githubusercontent.com/ourownstory/neuralprophet-data/main/datasets/"
+file = "energy/SF_hospital_load.csv"
+
+data_df = pd.read_csv(data_location + file)
+data_df.shape
+
+rng_2x = pd.date_range(start='2015-01-01 01:00:00', freq='H', periods=2*8760)
+y_2x = pd.concat([data_df['y'], data_df['y']], ignore_index=True)
+data_df_2x = pd.DataFrame({'ds': rng_2x, 'y': y_2x})
+data_df_2x.tail(5)
+
+rng_10x = pd.date_range(start='2015-01-01 01:00:00', freq='H', periods=10*8760)
+y_10x = pd.concat([data_df_2x['y'], data_df_2x['y'], data_df_2x['y'], data_df_2x['y'], data_df_2x['y']], ignore_index=True)
+data_df_10x = pd.DataFrame({'ds': rng_10x, 'y': y_10x})
+data_df_10x.shape
+
+quantile_lo, quantile_hi = 0.05, 0.95
+quantiles = [quantile_lo, quantile_hi]
+
+m = NeuralProphet(
+    epochs=1,
+    batch_size=128,
+    learning_rate=1.0,
+    n_forecasts=7,
+    n_lags=14,
+    quantiles=quantiles
+)
+
+m2x = NeuralProphet(
+    epochs=1,
+    batch_size=128,
+    learning_rate=1.0,
+    n_forecasts=7,
+    n_lags=14,
+    quantiles=quantiles
+)
+
+m10x = NeuralProphet(
+    epochs=1,
+    batch_size=128,
+    learning_rate=1.0,
+    n_forecasts=7,
+    n_lags=14,
+    quantiles=quantiles
+)
+
+metrics = m.fit(data_df, freq="H")
+metrics2x = m2x.fit(data_df_2x, freq="H")
+metrics10x = m10x.fit(data_df_10x, freq="H")
+
+forecast = m.predict(data_df)
+forecast2x = m2x.predict(data_df_2x)
+forecast10x = m10x.predict(data_df_10x)
+
+######## Test 1 ###########
+# get the start time
+st = time.time()
+
+fig1 = m.highlight_nth_step_ahead_of_each_forecast(1).plot(
+    forecast, plotting_backend='plotly').show()
+
+# get the end time
+et = time.time()
+elapsed_time = et - st
+print('Execution time test1:', elapsed_time, 'seconds')
+print('RAM memory % used:', psutil.virtual_memory()[2])
+print('RAM Used (GB):', psutil.virtual_memory()[3]/1000000000)
+
+######## Test 2 ###########
+# get the start time
+st = time.time()
+
+fig2 = m10x.highlight_nth_step_ahead_of_each_forecast(1).plot(
+    forecast10x, plotting_backend='plotly').show()
+
+# get the end time
+et = time.time()
+elapsed_time = et - st
+print('Execution time test2:', elapsed_time, 'seconds')
+print('RAM memory % used:', psutil.virtual_memory()[2])
+print('RAM Used (GB):', psutil.virtual_memory()[3]/1000000000)
+
+

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -26,7 +26,7 @@ LR = 1.0
 PLOT = False
 
 # plot tests cover both plotting backends
-decorator_input = ["plotting_backend", [("plotly"), ("matplotlib")]]
+decorator_input = ["plotting_backend", [("matplotlib"), ("plotly")]]
 
 
 @pytest.mark.parametrize(*decorator_input)
@@ -98,13 +98,13 @@ def test_plot_components(plotting_backend):
     # select components manually
     fig3 = m.plot_components(forecast, components=["autoregression"], plotting_backend="matplotlib")
     # select plotting components per period
-    fig4 = m.plot_components(forecast, one_period_per_season=True, plotting_backend="plotly")
+    fig4 = m.plot_components(forecast, one_period_per_season=True, plotting_backend=plotting_backend)
 
     log.info("Plot components with wrong component selection - Raise ValueError")
     with pytest.raises(ValueError):
-        m.plot_components(forecast, components=["quantiles"], plotting_backend="plotly")
+        m.plot_components(forecast, components=["quantiles"], plotting_backend=plotting_backend)
     with pytest.raises(ValueError):
-        m.plot_components(forecast, components=["trend123"], plotting_backend="plotly")
+        m.plot_components(forecast, components=["trend123"], plotting_backend=plotting_backend)
 
     if PLOT:
         fig1.show()
@@ -139,13 +139,13 @@ def test_plot_parameters(plotting_backend):
     fig2 = m.plot_parameters(plotting_backend=plotting_backend)
 
     # select components manually
-    fig3 = m.plot_parameters(components="trend", plotting_backend="plotly")
+    fig3 = m.plot_parameters(components="trend", plotting_backend=plotting_backend)
 
     log.info("Plot parameters with wrong component selection - Raise ValueError")
     with pytest.raises(ValueError):
-        m.plot_parameters(components=["events"], plotting_backend="plotly")
+        m.plot_parameters(components=["events"], plotting_backend=plotting_backend)
     with pytest.raises(ValueError):
-        m.plot_parameters(components=["trend123"], plotting_backend="plotly")
+        m.plot_parameters(components=["trend123"], plotting_backend=plotting_backend)
 
     if PLOT:
         fig1.show()
@@ -374,8 +374,8 @@ def test_plot_seasonality(plotting_backend):
     df = df[df["ds"].isin(bdays)]
     metrics_df = m.fit(df, freq="B")
     forecast = m.predict(df)
-    fig5 = m.plot_components(forecast, plotting_backend="plotly")
-    fig6 = m.plot_parameters(plotting_backend="plotly")
+    fig5 = m.plot_components(forecast, plotting_backend=plotting_backend)
+    fig6 = m.plot_parameters(plotting_backend=plotting_backend)
 
     if PLOT:
         fig1.show()
@@ -524,10 +524,10 @@ def test_plot_uncertainty(plotting_backend):
     forecast = m.predict(future)
     log.info("Plot multi-steps ahead forecast without autoregression - Raise ValueError")
     with pytest.raises(ValueError):
-        m.plot(forecast, plotting_backend="plotly", forecast_in_focus=4)
-        m.plot_components(forecast, plotting_backend="plotly", forecast_in_focus=4)
-        m.plot_components(forecast, plotting_backend="plotly", forecast_in_focus=None)
-        m.plot_parameters(quantile=0.75, plotting_backend="plotly", forecast_in_focus=4)
+        m.plot(forecast, plotting_backend=plotting_backend, forecast_in_focus=4)
+        m.plot_components(forecast, plotting_backend=plotting_backend, forecast_in_focus=4)
+        m.plot_components(forecast, plotting_backend=plotting_backend, forecast_in_focus=None)
+        m.plot_parameters(quantile=0.75, plotting_backend=plotting_backend, forecast_in_focus=4)
 
     if PLOT:
         fig1.show()


### PR DESCRIPTION
Credits @LeonieFreisinger 

## :microscope: Background

For **large datasets**, the **plotly** plotting_backend entails **large computation time** (in comparison to matplotlib) for plotting a figure. Additionally, when using an interactive renderer the plotted interactive figure in jupyter notebooks causes a **screen freeze** or **lagged interaction**.
**Goal:** Ideally, we will enable interactive rendering without lagged or freezing interaction.

## :crystal_ball: Key changes
- introduce [plotly-resampler](https://github.com/predict-idlab/plotly-resampler) to **reduze the granuarity** of figures. Plotly-resampler downsamples the data respective to a view.
- Downsampling is ensured for using the `'auto' `mode in all plotly-related `.py `files. --> `register_plotly_resampler(mode='auto')`
- Important note: Input data needs to have a `dtype `--> `list `is not accepted as input data. --> Change `lists `to `np.arrays`


## :clipboard: Review Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
