### PR TITLE
remove default settings (None for calibration df and 0.1 for alpha)

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -3105,7 +3105,7 @@ class NeuralProphet:
         return df_forecast
 
     def conformal_predict(
-        self, df, calibration_df=None, alpha=0.1, method="naive", plotting_backend="default", **kwargs
+        self, df, calibration_df, alpha, method="naive", plotting_backend="default", **kwargs
     ):
         """Apply a given conformal prediction technique to get the uncertainty prediction intervals (or q-hats). Then predict.
 
@@ -3114,7 +3114,7 @@ class NeuralProphet:
             df : pd.DataFrame
                 test dataframe containing column ``ds``, ``y``, and optionally ``ID`` with data
             calibration_df : pd.DataFrame
-                optional, holdout calibration dataframe for split conformal prediction
+                holdout calibration dataframe for split conformal prediction
             alpha : float
                 user-specified significance level of the prediction interval
             method : str

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -3104,9 +3104,7 @@ class NeuralProphet:
                         df_forecast = pd.concat([df_forecast, yhat_df], axis=1, ignore_index=False)
         return df_forecast
 
-    def conformal_predict(
-        self, df, calibration_df, alpha, method="naive", plotting_backend="default", **kwargs
-    ):
+    def conformal_predict(self, df, calibration_df, alpha, method="naive", plotting_backend="default", **kwargs):
         """Apply a given conformal prediction technique to get the uncertainty prediction intervals (or q-hats). Then predict.
 
         Parameters


### PR DESCRIPTION
## :microscope: Background
Make calibration dataset and alpha mandatory when the conformal predict function is being called

## :crystal_ball: Key changes
- Removed the default setting for calibration_df and alpha under theconformal_predict function
- Updated the comment for parameter as well

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
