### PR TITLE
Restict numpy version to <1.24.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-numpy>=1.15.4
+numpy>=1.15.4,<=1.23.5
 pandas>=1.0.4
 matplotlib>=2.0.0
 torch>=1.8.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-numpy>=1.15.4,<=1.23.5
+numpy>=1.15.4,<1.24.0
 pandas>=1.0.4
 matplotlib>=2.0.0
 torch>=1.8.0


### PR DESCRIPTION
## :microscope: Background

Numpy 1.24.0 seems to cause problem with the matplotlib plotting engine. Thus, we restrict numpy to <1.24.0 for the time being.

## :crystal_ball: Key changes

Restrict numpy to <1.24.0

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
