### PR TITLE
[Bug-fix] Enable test_plot_conformal_prediction with auto-regression on plot_latest_forecast

### DIFF
--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -586,7 +586,7 @@ def fcst_df_to_latest_forecast(fcst, quantiles, n_last=1):
     df = pd.concat((fcst[cols],), axis=1)
     df.reset_index(drop=True, inplace=True)
 
-    yhat_col_names = [col_name for col_name in fcst.columns if "yhat" in col_name and "%" not in col_name]
+    yhat_col_names = [col_name for col_name in fcst.columns if "yhat" in col_name and "%" not in col_name and "qhat" not in col_name]
     yhat_col_names_quants = [col_name for col_name in fcst.columns if "yhat" in col_name and "%" in col_name]
     n_forecast_steps = len(yhat_col_names)
     yhats = pd.concat((fcst[yhat_col_names],), axis=1)

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -586,7 +586,9 @@ def fcst_df_to_latest_forecast(fcst, quantiles, n_last=1):
     df = pd.concat((fcst[cols],), axis=1)
     df.reset_index(drop=True, inplace=True)
 
-    yhat_col_names = [col_name for col_name in fcst.columns if "yhat" in col_name and "%" not in col_name and "qhat" not in col_name]
+    yhat_col_names = [
+        col_name for col_name in fcst.columns if "yhat" in col_name and "%" not in col_name and "qhat" not in col_name
+    ]
     yhat_col_names_quants = [col_name for col_name in fcst.columns if "yhat" in col_name and "%" in col_name]
     n_forecast_steps = len(yhat_col_names)
     yhats = pd.concat((fcst[yhat_col_names],), axis=1)


### PR DESCRIPTION

## :microscope: Background

Fixes #1093 

`plot_latest_forecast()` throws an Error because with conformal prediction, a new column name `yhat1 +qhat` is inserted in the `forecast` dataframe, which we have not dealt with before. 

## :crystal_ball: Key changes

Ignore those new column names for now

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.