### PR TITLE
[Bug-fix] Enable holidays when using global/glocal modeling

### DIFF
--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -508,7 +508,7 @@ def make_events_features(df, config_events: Optional[configure.ConfigEvents] = N
         np.array
             All multiplicative event features (both user specified and country specific)
     """
-
+    df = df.reset_index(drop=True)
     additive_events = pd.DataFrame()
     multiplicative_events = pd.DataFrame()
 


### PR DESCRIPTION
## :microscope: Background

Fixes #1099
Adding country holidays with m.add_country_holidays() triggers an index error when the input df contains multiple time series (i.e. when glocal/global modeling is used).

## :crystal_ball: Key changes

 Resetting the index of the incoming time series in TimeDataset.make_events_features() resolves the problem.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.

