### PR TITLE
[Bug-fix] Refactor warning about global normalization to forecaster.py

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -759,6 +759,9 @@ class NeuralProphet:
             log.warning("Progress plot requires metrics to be enabled. Enabling the default metrics.")
             metrics = metrics.get_metrics(True)
 
+        if not self.config_normalization.global_normalization:
+            log.warning("When Global modeling with local normalization, metrics are displayed in normalized scale.")
+
         if minimal:
             checkpointing = False
             self.metrics = False

--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -1290,9 +1290,7 @@ class TimeNet(pl.LightningModule):
         -------
             denormalized timeseries
         """
-        if not self.config_normalization.global_normalization:
-            log.warning("When Global modeling with local normalization, metrics are displayed in normalized scale.")
-        else:
+        if self.config_normalization.global_normalization:
             shift_y = (
                 self.config_normalization.global_data_params["y"].shift
                 if self.config_normalization.global_normalization and not self.config_normalization.normalize == "off"


### PR DESCRIPTION
## :microscope: Background

Fixes #1053 
This code portion produced a warning on every single training step, which leads to huge, unnecessary log output. 
```
if not self.config_normalization.global_normalization:
     log.warning("When Global modeling with local normalization, metrics are displayed in normalized scale.")
else:
     ...
```

## :crystal_ball: Key changes

Moved the warning to `m.fit()`

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.
