### PR TITLE
[fix] default value of n_changepoints given correctly in the docs

### DIFF
--- a/docs/source/guides/hyperparameter-selection.md
+++ b/docs/source/guides/hyperparameter-selection.md
@@ -71,7 +71,7 @@ If a list of `changepoints` is supplied, `n_changepoints` and `changepoints_rang
 This list is instead used to set the dates at which the trend rate is allowed to change.
 
 `n_changepoints` is the number of changepoints selected along the series for the trend. The default
-value for this is 5.
+value for this is 10.
 
 ## Seasonality Related Parameters
 `yearly_seasonality`, `weekly_seasonality` and `daily_seasonality` are about which seasonal components to be modelled. For example, if you use temperature data, 

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -257,6 +257,7 @@ class Trend:
 
         if self.changepoints is not None:
             self.n_changepoints = len(self.changepoints)
+            # test comment
             self.changepoints = pd.to_datetime(self.changepoints).sort_values().values
 
         if self.trend_reg_threshold is None:

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -257,7 +257,6 @@ class Trend:
 
         if self.changepoints is not None:
             self.n_changepoints = len(self.changepoints)
-            # test comment
             self.changepoints = pd.to_datetime(self.changepoints).sort_values().values
 
         if self.trend_reg_threshold is None:


### PR DESCRIPTION
## :microscope: Background
In the guide hyperparemeter-selection, it says 
'`n_changepoints` is the number of changepoints selected along the series for the trend. The default value for this is 5.' 
But the correct value would be 10, being consistent with the code.

## :crystal_ball: Key changes
Changed the value of 5 to 10 in the guide

## :clipboard: Review Checklist
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, added docstrings and data types to function definitions.
- [X] I have added pytests to check whether my feature / fix works.