### PR TITLE
Allow unique values for future regressor of one time series in global modeling

### DIFF
--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -142,7 +142,7 @@ def data_params_definition(
     config_regressors=None,
     config_events: Optional[ConfigEvents] = None,
     config_seasonality: Optional[ConfigSeasonality] = None,
-    local_run_despite_global: Optional[bool] = None
+    local_run_despite_global: Optional[bool] = None,
 ):
     """
     Initialize data scaling values.
@@ -325,7 +325,7 @@ def init_data_params(
             config_regressors,
             config_events,
             config_seasonality,
-            local_run_despite_global
+            local_run_despite_global,
         )
         if global_time_normalization:
             # Overwrite local time normalization data_params with global values (pointer)

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -142,7 +142,7 @@ def data_params_definition(
     config_regressors=None,
     config_events: Optional[ConfigEvents] = None,
     config_seasonality: Optional[ConfigSeasonality] = None,
-    local_run_despite_global: Optional[bool]=None
+    local_run_despite_global: Optional[bool] = None
 ):
     """
     Initialize data scaling values.
@@ -219,7 +219,7 @@ def data_params_definition(
             norm_type = config_regressors[reg].normalize
             if local_run_despite_global:
                 if len(df[reg].unique()) < 2:
-                    norm_type = 'soft'
+                    norm_type = "soft"
             data_params[reg] = get_normalization_params(
                 array=df[reg].values,
                 norm_type=norm_type,
@@ -319,7 +319,13 @@ def init_data_params(
     for df_name, df_i in df.groupby("ID"):
         df_i.drop("ID", axis=1, inplace=True)
         local_data_params[df_name] = data_params_definition(
-            df_i, normalize, config_lagged_regressors, config_regressors, config_events, config_seasonality, local_run_despite_global
+            df_i,
+            normalize,
+            config_lagged_regressors,
+            config_regressors,
+            config_events,
+            config_seasonality,
+            local_run_despite_global
         )
         if global_time_normalization:
             # Overwrite local time normalization data_params with global values (pointer)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ pandas>=1.0.4
 plotly>=5.12.0
 plotly_resampler>=0.8.3
 python-dateutil>=2.8.0
-pytorch-lightning==1.7.4
-rich==12.4.4
+pytorch-lightning>=1.7
+tensorboard
 torch>=1.8.0
-torchmetrics==0.9.3
+torchmetrics>=0.9.3
 typing_extensions>=4.4.0;python_version<'3.8'
 widgetsnbextension>=4.0.5


### PR DESCRIPTION

## :microscope: Background
Fixes #1130 
Currently, NeuralProphet does not allow a future regressor to only contain unique values. When global modeling, however, there are reasonable cases in which some IDs may have only unique values, while others don't. 

## :crystal_ball: Key changes

Instead of throwing an Error immediately, we first check whether we have unique values cross all IDs. If not, we give a warning. 

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.
