### PR TITLE
[Feature] Enable own NN configuration for lagged regressors

### DIFF
--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -383,6 +383,8 @@ class LaggedRegressor:
     as_scalar: bool
     normalize: Union[bool, str]
     n_lags: int
+    num_hidden_layers: Optional[int]
+    d_hidden : Optional[int]
 
     def __post_init__(self):
         if self.reg_lambda is not None:

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -448,6 +448,8 @@ class NeuralProphet:
         self,
         names: Union[str, List[str]],
         n_lags: Union[int, np_types.Literal["auto", "scalar"]] = "auto",
+        num_hidden_layers: Optional[int] = None,
+        d_hidden: Optional[int] = None,
         regularization: Optional[float] = None,
         normalize: Union[bool, str] = "auto",
     ):
@@ -463,12 +465,20 @@ class NeuralProphet:
                 previous regressors time steps to use as input in the predictor (covar order)
                 if ``auto``, time steps will be equivalent to the AR order (default)
                 if ``scalar``, all the regressors will only use last known value as input
+            num_hidden_layers : int
+                number of hidden layers to include in Lagged-Regressor-Net (defaults to same configuration as AR-Net)
+            d_hidden : int
+                dimension of hidden layers of the Lagged-Regressor-Net. Ignored if ``num_hidden_layers`` == 0.
             regularization : float
                 optional  scale for regularization strength
             normalize : bool
                 optional, specify whether this regressor will benormalized prior to fitting.
                 if ``auto``, binary regressors will not be normalized.
         """
+        if num_hidden_layers is None:
+            num_hidden_layers = self.config_model.num_hidden_layers
+        if d_hidden is None:
+            d_hidden = self.config_model.d_hidden
         if n_lags == 0 or n_lags is None:
             n_lags = 0
             log.warning(
@@ -502,6 +512,8 @@ class NeuralProphet:
                 normalize=normalize,
                 as_scalar=only_last_value,
                 n_lags=n_lags,
+                num_hidden_layers=num_hidden_layers,
+                d_hidden=d_hidden
             )
         return self
 

--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -303,17 +303,17 @@ class TimeNet(pl.LightningModule):
             for covar in self.config_lagged_regressors.keys():
                 covar_net = nn.ModuleList()
                 d_inputs = self.config_lagged_regressors[covar].n_lags
-                for i in range(self.num_hidden_layers):
+                for i in range(self.config_lagged_regressors[covar].num_hidden_layers):
                     d_hidden = (
                         max(
                             4,
                             round(
                                 (self.config_lagged_regressors[covar].n_lags + n_forecasts)
-                                / (2.0 * (num_hidden_layers + 1))
+                                / (2.0 * (self.config_lagged_regressors[covar].num_hidden_layers + 1))
                             ),
                         )
-                        if d_hidden is None
-                        else d_hidden
+                        if self.config_lagged_regressors[covar].d_hidden is None
+                        else self.config_lagged_regressors[covar].d_hidden
                     )
                     covar_net.append(nn.Linear(d_inputs, d_hidden, bias=True))
                     d_inputs = d_hidden
@@ -499,7 +499,7 @@ class TimeNet(pl.LightningModule):
                 Forecast component of dims (batch, n_forecasts)
         """
         x = lags
-        for i in range(self.num_hidden_layers + 1):
+        for i in range(self.config_lagged_regressors[name].num_hidden_layers + 1):
             if i > 0:
                 x = nn.functional.relu(x)
             x = self.covar_nets[name][i](x)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -378,7 +378,7 @@ def test_lag_reg():
     )
     df["A"] = df["y"].rolling(7, min_periods=1).mean()
     df["B"] = df["y"].rolling(30, min_periods=1).mean()
-    m = m.add_lagged_regressor(names="A")
+    m = m.add_lagged_regressor(names="A", n_lags=12, num_hidden_layers=4, d_hidden=16)
     m = m.add_lagged_regressor(names="B")
     metrics_df = m.fit(df, freq="D")
     future = m.make_future_dataframe(df, n_historic_predictions=10)


### PR DESCRIPTION
## :microscope: Background

Fixes #1147 
Currently, when adding lagged regressors to the model, they follow the same configuration for `num_hidden_layers` and `d_hidden` as the AR-net specified for autoregression. We would like to change that, adding an individual configuration in `m.add_lagged_regressor()`

## :crystal_ball: Key changes

`m.add_lagged_regressor()` accepts new input arguments: `num_hidden_layers` and `d_hidden`. 

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.