### PR TITLE
[minor] Refactored Learning Rate Finder

### DIFF
--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -726,10 +726,6 @@ def smooth_loss_and_suggest(lr_finder_results, window=10):
     try:
         # Find the steepest gradient and the minimum loss after that
         steepest_gradient_idx = np.argmin(np.gradient(loss))
-        min_loss_idx = np.argmin(loss[steepest_gradient_idx:])
-        # Select the average of the two (more conservative than just using the steepest gradient)
-        loss_idx = steepest_gradient_idx + int(min_loss_idx / 2)
-        # TODO: decide which idx to use
         suggestion = lr_finder_results["lr"][steepest_gradient_idx]
     except ValueError:
         log.error(

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -729,7 +729,8 @@ def smooth_loss_and_suggest(lr_finder_results, window=10):
         min_loss_idx = np.argmin(loss[steepest_gradient_idx:])
         # Select the average of the two (more conservative than just using the steepest gradient)
         loss_idx = steepest_gradient_idx + int(min_loss_idx / 2)
-        suggestion = lr_finder_results["lr"][loss_idx]
+        # TODO: decide which idx to use
+        suggestion = lr_finder_results["lr"][steepest_gradient_idx]
     except ValueError:
         log.error(
             f"The number of loss values ({len(loss)}) is too small to estimate a learning rate. Increase the number of samples or manually set the learning rate."

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -705,10 +705,11 @@ def smooth_loss_and_suggest(lr_finder_results, window=10):
             Suggested learning rate based on gradient
     """
     lr = lr_finder_results["lr"]
+    loss = lr_finder_results["loss"]
     # Derive window size from num lr searches, ensure window is divisible by 2
     half_window = math.ceil(round(len(loss) * 0.1) / 2)
     # Pad sequence and initialialize hamming filter
-    loss = np.pad(np.array(lr_finder_results["loss"]), pad_width=half_window, mode="edge")
+    loss = np.pad(np.array(loss), pad_width=half_window, mode="edge")
     window = np.hamming(half_window * 2)
     # Convolve the over the loss distribution
     try:

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -725,8 +725,7 @@ def smooth_loss_and_suggest(lr_finder_results, window=10):
     # Suggest the lr with steepest negative gradient
     try:
         # Find the steepest gradient and the minimum loss after that
-        steepest_gradient_idx = np.argmin(np.gradient(loss))
-        suggestion = lr_finder_results["lr"][steepest_gradient_idx]
+        suggestion = lr[np.argmin(np.gradient(loss))]
     except ValueError:
         log.error(
             f"The number of loss values ({len(loss)}) is too small to estimate a learning rate. Increase the number of samples or manually set the learning rate."


### PR DESCRIPTION
## :microscope: Background

- The default learning rate finder by lightning does not smooth the loss results, thus the results yielded are unstable.
- A first implementation of the loss smoothing has been implemented with the introduction of lightning.

## :crystal_ball: Key changes

- This PR improves the smoother implementation and applies a more conservative learning rate selection function.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
