### PR TITLE
[devops] Downgrade python to 3.7 for pyright

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.7"
           cache: "pip"
           cache-dependency-path: "**/requirements/*.txt"
       - name: Setup Requirements

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -54,7 +54,7 @@ def prep_or_copy_df(df: pd.DataFrame) -> tuple[pd.DataFrame, bool, bool, list[st
         return df_copy, df_has_id_column, True, ["__df__"]
 
     # Create a list of unique ID values
-    unique_id_values: list[str] = df_copy["ID"].unique().tolist()
+    unique_id_values = list(df_copy["ID"].unique())
     # Check if there is only one unique ID value
     df_has_single_time_series = len(unique_id_values) == 1
 


### PR DESCRIPTION
## :microscope: Background

- We support both python version, but we get new errors in python `3.10` which do not exist in `3.7` (`3.7` is most important for colab and other use cases, so focus on that)

## :crystal_ball: Key changes

- Change python version to `3.7` from `3.10` for pyright