### PR TITLE
[minor] Adjust seasonality reg to modularized code

### DIFF
--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -898,7 +898,7 @@ class TimeNet(pl.LightningModule):
                 l_season = self.config_seasonality.reg_lambda
                 if self.seasonality.season_dims is not None and l_season is not None and l_season > 0:
                     for name in self.seasonality.season_params.keys():
-                        reg_season = utils.reg_func_season(self.seasonality.season_params[name])
+                        reg_season = utils.reg_func_season(self. seasonality.season_params[name])
                         reg_loss += l_season * reg_season
 
             # Regularize events: sparsify events features coefficients

--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -897,8 +897,8 @@ class TimeNet(pl.LightningModule):
             if self.config_seasonality:
                 l_season = self.config_seasonality.reg_lambda
                 if self.seasonality.season_dims is not None and l_season is not None and l_season > 0:
-                    for name in self.season_params.keys():
-                        reg_season = utils.reg_func_season(self.season_params[name])
+                    for name in self.seasonality.season_params.keys():
+                        reg_season = utils.reg_func_season(self.seasonality.season_params[name])
                         reg_loss += l_season * reg_season
 
             # Regularize events: sparsify events features coefficients

--- a/neuralprophet/time_net.py
+++ b/neuralprophet/time_net.py
@@ -898,7 +898,7 @@ class TimeNet(pl.LightningModule):
                 l_season = self.config_seasonality.reg_lambda
                 if self.seasonality.season_dims is not None and l_season is not None and l_season > 0:
                     for name in self.seasonality.season_params.keys():
-                        reg_season = utils.reg_func_season(self. seasonality.season_params[name])
+                        reg_season = utils.reg_func_season(self.seasonality.season_params[name])
                         reg_loss += l_season * reg_season
 
             # Regularize events: sparsify events features coefficients


### PR DESCRIPTION
## :microscope: Background

Bug because `self.season_params` does not exist anymore with the newly modularized seasonality. 

## :crystal_ball: Key changes

Change to `self.seasonality.season_params`

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.