### PR TITLE
[refactor] Modified n_forecasts in  _infer_evaluate_params_from_dataset() method in conformal.py

### DIFF
--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -219,7 +219,7 @@ def test_split_conformal_prediction():
             method=method,
             decompose=decompose,
         )
-        eval_df = conformal_evaluate(forecast)
+        eval_df = uncertainty_evaluate(forecast)
 
         if PLOT:
             fig1 = m.plot(forecast)

--- a/tutorials/feature-use/uncertainty_conformal_prediction.ipynb
+++ b/tutorials/feature-use/uncertainty_conformal_prediction.ipynb
@@ -215,7 +215,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.024819374084472656,
+       "elapsed": 0.03274655342102051,
        "initial": 0,
        "n": 0,
        "ncols": null,
@@ -229,7 +229,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c41068c8678d4583bae0f1d4a2f972a6",
+       "model_id": "34c4dc3ff02d42fba28e4894b130278b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -246,7 +246,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.04771733283996582,
+       "elapsed": 0.0334324836730957,
        "initial": 0,
        "n": 0,
        "ncols": null,
@@ -260,7 +260,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "82849b51b3aa49f8b9074791d7534bef",
+       "model_id": "8122cdec28a14273a2682cc2e6836509",
        "version_major": 2,
        "version_minor": 0
       },
@@ -289,7 +289,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.05789494514465332,
+       "elapsed": 0.03058767318725586,
        "initial": 0,
        "n": 0,
        "ncols": null,
@@ -303,7 +303,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1d0810a44641423984d265712d6efd84",
+       "model_id": "41868193812d4834ab373c02a0e0d8f9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -352,7 +352,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.02366471290588379,
+       "elapsed": 0.030905485153198242,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -366,7 +366,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9fbd4dab359e46de8c2a13ed82e90c94",
+       "model_id": "2b9a8803bba449abb39c21fc090d46c7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -394,7 +394,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.020302534103393555,
+       "elapsed": 0.03635859489440918,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -408,7 +408,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "96fd0266e33146ce856e936dce7cbefd",
+       "model_id": "cbc0ef5c0adc499f80de602715bb9da4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -526,7 +526,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.03931784629821777,
+       "elapsed": 0.02094268798828125,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -540,7 +540,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ed91323073742b18923fb277ee2dcc1",
+       "model_id": "0c7ebb3d317e4c20b4c4bfb19ef97cc4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -568,7 +568,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.021048784255981445,
+       "elapsed": 0.022035598754882812,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -582,7 +582,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b62bee3b987a48529db4bdc41e9f95f4",
+       "model_id": "fb78bbdffc59459183033d7ea524e770",
        "version_major": 2,
        "version_minor": 0
       },
@@ -610,7 +610,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.06021761894226074,
+       "elapsed": 0.024440526962280273,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -624,7 +624,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8ee6cebbe43443a596d3d158ba88ced2",
+       "model_id": "3385d5ccdf0f4648afb6ee122b87822e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -652,7 +652,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.03695416450500488,
+       "elapsed": 0.0373835563659668,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -666,7 +666,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c561134017d94a9ca996ed45807df871",
+       "model_id": "fe9548c42c2049d3921ea7fa1fb4a7ce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -844,7 +844,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.03137922286987305,
+       "elapsed": 0.037969350814819336,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -858,7 +858,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "728481935bf84be69f74323bb32b3eb2",
+       "model_id": "6dd8052d4dad4938a7baaca22952a1d7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -886,7 +886,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.025582075119018555,
+       "elapsed": 0.023046493530273438,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -900,7 +900,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6af1124d24c442309cc50b585382ed9c",
+       "model_id": "266e40a935a14cf5aadaa5769df822e2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -928,7 +928,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.03789019584655762,
+       "elapsed": 0.061977386474609375,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -942,7 +942,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "412f1b5c0f9442f687b2e838dd367652",
+       "model_id": "5b618fd192794dffb951ee21ade7f5eb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -970,7 +970,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.02667999267578125,
+       "elapsed": 0.028913259506225586,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -984,7 +984,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c9fbcc91a55c406f963cdb75668a2027",
+       "model_id": "a58eaef056a7410cb3acd8a51cfafb4c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1155,7 +1155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1173,7 +1173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1198,7 +1198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1281,7 +1281,7 @@
        "1         0.071579  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
## :microscope: Background

- Allows conformal evaluation for double-digit (and beyond) multistep forecasting.

## :crystal_ball: Key changes

- Change the way how n_forecasts is extracted.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
