### PR TITLE
[refactor] Add quantile regression (QR) as an uncertainty evalution metric in uncertainty.py

### DIFF
--- a/neuralprophet/uncertainty.py
+++ b/neuralprophet/uncertainty.py
@@ -61,25 +61,21 @@ class Conformal:
             # conformalize
             noncon_scores = self._get_nonconformity_scores(df_cal, step_number)
             q_hat = self._get_q_hat(df_cal, noncon_scores)
-            df[f"qhat{step_number}"] = q_hat
+            q_hat_col = f"qhat{step_number}"
+            y_hat_col = f"yhat{step_number}"
+            df[q_hat_col] = q_hat
             if self.method == "naive":
-                df[f"yhat{step_number} - qhat{step_number}"] = df[f"yhat{step_number}"] - q_hat
-                df[f"yhat{step_number} + qhat{step_number}"] = df[f"yhat{step_number}"] + q_hat
+                df[f"{y_hat_col} - {q_hat_col}"] = df[y_hat_col] - q_hat
+                df[f"{y_hat_col} + {q_hat_col}"] = df[y_hat_col] + q_hat
             elif self.method == "cqr":
                 quantile_lo = str(min(self.quantiles) * 100)
                 quantile_hi = str(max(self.quantiles) * 100)
-                df[f"yhat{step_number} {quantile_lo}% - qhat{step_number}"] = (
-                    df[f"yhat{step_number} {quantile_lo}%"] - q_hat
-                )
-                df[f"yhat{step_number} {quantile_lo}% + qhat{step_number}"] = (
-                    df[f"yhat{step_number} {quantile_lo}%"] + q_hat
-                )
-                df[f"yhat{step_number} {quantile_hi}% - qhat{step_number}"] = (
-                    df[f"yhat{step_number} {quantile_hi}%"] - q_hat
-                )
-                df[f"yhat{step_number} {quantile_hi}% + qhat{step_number}"] = (
-                    df[f"yhat{step_number} {quantile_hi}%"] + q_hat
-                )
+                quantile_lo_col = f"{y_hat_col} {quantile_lo}%"
+                quantile_hi_col = f"{y_hat_col} {quantile_hi}%"
+                df[f"{quantile_lo_col} - {q_hat_col}"] = df[quantile_lo_col] - q_hat
+                df[f"{quantile_lo_col} + {q_hat_col}"] = df[quantile_lo_col] + q_hat
+                df[f"{quantile_hi_col} - {q_hat_col}"] = df[quantile_hi_col] - q_hat
+                df[f"{quantile_hi_col} + {q_hat_col}"] = df[quantile_hi_col] + q_hat
             else:
                 raise ValueError(
                     f"Unknown conformal prediction method '{self.method}'. Please input either 'naive' or 'cqr'."
@@ -107,22 +103,22 @@ class Conformal:
                     nonconformity scores from the calibration datapoints
 
         """
+        y_hat_col = f"yhat{step_number}"
         if self.method == "cqr":
             # CQR nonconformity scoring function
             quantile_lo = str(min(self.quantiles) * 100)
             quantile_hi = str(max(self.quantiles) * 100)
+            quantile_lo_col = f"{y_hat_col} {quantile_lo}%"
+            quantile_hi_col = f"{y_hat_col} {quantile_hi}%"
             cqr_scoring_func = (
                 lambda row: [None, None]
-                if row[f"yhat{step_number} {quantile_lo}%"] is None or row[f"yhat{step_number} {quantile_hi}%"] is None
+                if row[quantile_lo_col] is None or row[quantile_hi_col] is None
                 else [
                     max(
-                        row[f"yhat{step_number} {quantile_lo}%"] - row["y"],
-                        row["y"] - row[f"yhat{step_number} {quantile_hi}%"],
+                        row[quantile_lo_col] - row["y"],
+                        row["y"] - row[quantile_hi_col],
                     ),
-                    0
-                    if row[f"yhat{step_number} {quantile_lo}%"] - row["y"]
-                    > row["y"] - row[f"yhat{step_number} {quantile_hi}%"]
-                    else 1,
+                    0 if row[quantile_lo_col] - row["y"] > row["y"] - row[quantile_hi_col] else 1,
                 ]
             )
             scores_df = df_cal.apply(cqr_scoring_func, axis=1, result_type="expand")
@@ -130,7 +126,7 @@ class Conformal:
             noncon_scores = scores_df["scores"].values
         else:  # self.method == "naive"
             # Naive nonconformity scoring function
-            noncon_scores = abs(df_cal["y"] - df_cal[f"yhat{step_number}"]).values
+            noncon_scores = abs(df_cal["y"] - df_cal[y_hat_col]).values
         # Remove NaN values
         noncon_scores: Any = noncon_scores[~pd.isnull(noncon_scores)]
         # Sort
@@ -228,49 +224,41 @@ def uncertainty_evaluate(df_forecast: pd.DataFrame) -> pd.DataFrame:
     df_eval = pd.DataFrame()
     # Begin conformal evaluation steps
     for step_number in range(1, n_forecasts + 1):
-        q_hat = df_forecast_eval.iloc[0]["qhat1"]
+        q_hat_col = f"qhat{step_number}"
+        y_hat_col = f"yhat{step_number}"
+        q_hat = df_forecast_eval.iloc[0][q_hat_col]
+        # QR Interval Evaluation (if quantiles lo & hi both exist)
+        if quantile_lo and quantile_hi:
+            quantile_lo_col = f"{y_hat_col} {quantile_lo}%"
+            quantile_hi_col = f"{y_hat_col} {quantile_hi}%"
+            # Get QR evaluation metrics
+            interval_width, miscoverage_rate = _get_evaluate_metrics_from_dataset(
+                df_forecast_eval, quantile_lo_col, quantile_hi_col
+            )
+            # Construct row dataframe with current timestep using its q-hat, interval width, and miscoverage rate
+            col_names = ["interval_width", "miscoverage_rate"]
+            row = [interval_width, miscoverage_rate]
+            df_row = pd.DataFrame([row], columns=pd.MultiIndex.from_product([[y_hat_col], ["qr"], col_names]))
+            # Add row dataframe to overall evaluation dataframe with all forecasted timesteps
+            df_eval = pd.concat([df_eval, df_row], axis=1)
+        # Naive CP Interval Evaluation
         if method == "naive":
-            # Interval width (efficiency metric)
-            interval_width = q_hat * 2
-            # Miscoverage rate (validity metric)
-            n_covered = df_forecast_eval.apply(
-                lambda row: bool(
-                    row[f"yhat{step_number} - qhat{step_number}"]
-                    <= row["y"]
-                    <= row[f"yhat{step_number} + qhat{step_number}"]
-                ),
-                axis=1,
-            )
-            coverage_rate = n_covered.sum() / len(df_forecast_eval)
-            miscoverage_rate = 1 - coverage_rate
+            quantile_lo_col = f"{y_hat_col} - {q_hat_col}"
+            quantile_hi_col = f"{y_hat_col} + {q_hat_col}"
+        # CQR Interval Evaluation
         elif method == "cqr":
-            # Interval width (efficiency metric)
-            quantile_lo_mean = (
-                df_forecast_eval[f"yhat{step_number}"].mean()
-                - df_forecast_eval[f"yhat{step_number} {quantile_lo}"].mean()
-            )
-            quantile_hi_mean = (
-                df_forecast_eval[f"yhat{step_number} {quantile_hi}"].mean()
-                - df_forecast_eval[f"yhat{step_number}"].mean()
-            )
-            interval_width = quantile_lo_mean + quantile_hi_mean + q_hat * 2
-            # Miscoverage rate (validity metric)
-            n_covered = df_forecast_eval.apply(
-                lambda row: bool(
-                    row[f"yhat{step_number} {quantile_lo} - qhat{step_number}"]
-                    <= row["y"]
-                    <= row[f"yhat{step_number} {quantile_hi} + qhat{step_number}"]
-                ),
-                axis=1,
-            )
-            coverage_rate = n_covered.sum() / len(df_forecast_eval)
-            miscoverage_rate = 1 - coverage_rate
+            quantile_lo_col = f"{y_hat_col} {quantile_lo}% - {q_hat_col}"
+            quantile_hi_col = f"{y_hat_col} {quantile_hi}% + {q_hat_col}"
         else:
             raise ValueError(f"Unknown conformal prediction method '{method}'. Please input either 'naive' or 'cqr'.")
+        # Get CP evaluation metrics
+        interval_width, miscoverage_rate = _get_evaluate_metrics_from_dataset(
+            df_forecast_eval, quantile_lo_col, quantile_hi_col
+        )
         # Construct row dataframe with current timestep using its q-hat, interval width, and miscoverage rate
-        row = [q_hat, interval_width, miscoverage_rate]
         col_names = [f"qhat{step_number}", "interval_width", "miscoverage_rate"]
-        df_row = pd.DataFrame([row], columns=pd.MultiIndex.from_product([[f"yhat{step_number}"], col_names]))
+        row = [q_hat, interval_width, miscoverage_rate]
+        df_row = pd.DataFrame([row], columns=pd.MultiIndex.from_product([[y_hat_col], [method], col_names]))
         # Add row dataframe to overall evaluation dataframe with all forecasted timesteps
         df_eval = pd.concat([df_eval, df_row], axis=1)
 
@@ -292,20 +280,55 @@ def _infer_evaluate_params_from_dataset(
         str, int, Optional[str], Optional[str]
             parameters to evaluate conformal prediction, only cqr outputs quantile_lo and quantile_hi
     """
-    pattern = "yhat1\\ (.*)?\\ ?\\+\\ qhat1"
-    qhat_col = [col for col in df_forecast_eval.columns if col[:4] == "qhat"]
     # Get n_forecasts
+    qhat_col = [col for col in df_forecast_eval.columns if col[:4] == "qhat"]
     n_forecasts = int(qhat_col[-1].replace("qhat", ""))
     # Extract conformal prediction forecast column(s)
-    cp_col = [col for col in df_forecast_eval if re.compile(pattern).match(col)]
-    if len(cp_col) == 1:
-        # Get Naive method
-        method = "naive"
-        return method, n_forecasts, None, None
+    cp_pattern = "yhat1\\ (.*)?\\%\\ \\+\\ qhat1"
+    cp_col = [col for col in df_forecast_eval if re.compile(cp_pattern).match(col)]
+    # Get Naive method if only "yhat1 + qhat1" exist and CQR if "yhat1 {quantile} + qhat1" for both lo & hi exist
+    method = "cqr" if len(cp_col) == 2 else "naive"
+    # Extract quantile regression forecast column(s)
+    qr_pattern = "yhat1\\ (.*)?\\%$"
+    qr_col = [col for col in df_forecast_eval if re.compile(qr_pattern).match(col)]
+    # Get quantile lo & hi if QR exists else set both to None
+    if len(qr_col) == 2:
+        quantile_lo = re.findall(qr_pattern, qr_col[0])[0]
+        quantile_hi = re.findall(qr_pattern, qr_col[1])[0]
     else:
-        # Get CQR method
-        method = "cqr"
-        # Get quantile_lo and quantile_hi
-        quantile_lo = re.findall(pattern, cp_col[0])[0].strip()
-        quantile_hi = re.findall(pattern, cp_col[1])[0].strip()
-        return method, n_forecasts, quantile_lo, quantile_hi
+        quantile_lo = None
+        quantile_hi = None
+
+    return method, n_forecasts, quantile_lo, quantile_hi
+
+
+def _get_evaluate_metrics_from_dataset(
+    df_forecast_eval: pd.DataFrame,
+    quantile_lo_col: str,
+    quantile_hi_col: str,
+) -> Tuple[float, float]:
+    """Infers evaluation parameters based on the evaluation dataframe columns.
+
+    Parameters
+    ----------
+        df_forecast_eval : pd.DataFrame
+            forecast dataframe with the conformal prediction intervals
+
+    Returns
+    -------
+        float, float
+            conformal prediction evaluation metrics
+    """
+    # Interval width (efficiency metric)
+    quantile_lo_mean = df_forecast_eval[quantile_lo_col].mean()
+    quantile_hi_mean = df_forecast_eval[quantile_hi_col].mean()
+    interval_width = quantile_hi_mean - quantile_lo_mean
+    # Miscoverage rate (validity metric)
+    n_covered = df_forecast_eval.apply(
+        lambda row: bool(row[quantile_lo_col] <= row["y"] <= row[quantile_hi_col]),
+        axis=1,
+    )
+    coverage_rate = n_covered.sum() / len(df_forecast_eval)
+    miscoverage_rate = 1 - coverage_rate
+
+    return interval_width, miscoverage_rate

--- a/tutorials/feature-use/uncertainty_conformal_prediction.ipynb
+++ b/tutorials/feature-use/uncertainty_conformal_prediction.ipynb
@@ -1327,19 +1327,12 @@
     "**Performance of the trained model above**:\n",
     "\n",
     "- This notebook is only using single forecast timestep models, hence we would only have `yhat1` as the point estimator.\n",
-    "- Both conformal prediction methods (*Naive* and *CQR*), significantly outperforms QR in terms of `miscoverage_rate`.\n",
-    "- The `interval_width` doubles the quantified uncertainties (`qhat1`) for both the Naive conformal predictions, as such you will be seeing symmetrical prediction intervals.\n",
-    "- The complex model (m2) has a lower `interval_width` and `miscoverage_rate` than the simple model (m1). The simpler model (m1) have *miscoverage rate* bigger than the confidence level (*alpha* at 0.1) while the complex autoregressioin model (m2) have a *miscoverage rate* smaller than the confidence level. As such, we can conclude that the more complex the model is, the better the data are fitted and the more accurate the prediction are made. \n",
-    "- When we are only looking at the simple quantile regression model (m1), CQR is more preferable as it has narrower prediction *interval width* yet similar *miscoverage rate* than Naive.\n",
-    "- As for the complex model (m2), Naive has a slightly better *interval width*, but CQR has a slightly better *miscoverage rate*. You may want to feed the model with more data to determine which method more preferable.\n"
+    "- Both conformal prediction methods (**Naive** and **CQR**), significantly outperforms vanilla **QR** in terms of `miscoverage_rate`. This shows that the **QR** is *too overconfident* in its quantile values. Hence the `interval_width` needs to be *broadened further* in order for its actual `miscoverage_rate` (on out-of-sample test set) to converge to the specified `alpha` at `0.1` (from calibration set).\n",
+    "- The `interval_width` doubles the quantified uncertainties (`qhat1`) for both the **Naive** conformal predictions, as such you will be seeing symmetrical prediction intervals.\n",
+    "- The complex model (`m2`) has a lower `interval_width` and `miscoverage_rate` than the simple model (`m1`), acroos all uncertainty methods. The simpler model (`m1`) have `miscoverage_rate` bigger than the confidence level (i.e., 90% or 1-`alpha`) while the complex autoregressioin model (`m2`) have a `miscoverage_rate` smaller than the confidence level. As such, we can conclude that *the more complex the model is, the better the data are fitted and the more accurate the prediction are made*. \n",
+    "- When we are only looking at the simple quantile regression model (`m1`), **CQR** is more preferable as it has narrower prediction `interval_width` yet similar `miscoverage_rate` than **Naive**.\n",
+    "- As for the complex model (`m2`), **Naive** has a slightly better `interval_width`, but **CQR** has a slightly better `miscoverage_rate`. You may want to feed the model with more data to determine which method more preferable.\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/feature-use/uncertainty_conformal_prediction.ipynb
+++ b/tutorials/feature-use/uncertainty_conformal_prediction.ipynb
@@ -215,7 +215,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.03274655342102051,
+       "elapsed": 0.026133060455322266,
        "initial": 0,
        "n": 0,
        "ncols": null,
@@ -229,7 +229,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34c4dc3ff02d42fba28e4894b130278b",
+       "model_id": "e27d96e65c4b4f78b67497fa7f80196b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -246,7 +246,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.0334324836730957,
+       "elapsed": 0.047040462493896484,
        "initial": 0,
        "n": 0,
        "ncols": null,
@@ -260,7 +260,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8122cdec28a14273a2682cc2e6836509",
+       "model_id": "b15baa81db124ffa93570f18cade6fe4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -289,7 +289,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.03058767318725586,
+       "elapsed": 0.0388641357421875,
        "initial": 0,
        "n": 0,
        "ncols": null,
@@ -303,7 +303,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "41868193812d4834ab373c02a0e0d8f9",
+       "model_id": "49b035bd7ea34c90a5f84509dcbd4564",
        "version_major": 2,
        "version_minor": 0
       },
@@ -313,9 +313,18 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5min 12s, sys: 497 ms, total: 5min 13s\n",
+      "Wall time: 8min 7s\n"
+     ]
     }
    ],
    "source": [
+    "%%time\n",
     "# Feed the training subset in the configured NeuralProphet models\n",
     "# Configure the hourly frequency by assigning 'H' to parameter freq\n",
     "set_random_seed(0)\n",
@@ -352,7 +361,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.030905485153198242,
+       "elapsed": 0.03351783752441406,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -366,7 +375,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2b9a8803bba449abb39c21fc090d46c7",
+       "model_id": "9c10229130d1459c8126abed44f05e1a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -394,7 +403,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.03635859489440918,
+       "elapsed": 0.035462141036987305,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -408,7 +417,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cbc0ef5c0adc499f80de602715bb9da4",
+       "model_id": "da7114a393304f46be1761ffd7aefc38",
        "version_major": 2,
        "version_minor": 0
       },
@@ -526,7 +535,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.02094268798828125,
+       "elapsed": 0.03704094886779785,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -540,7 +549,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0c7ebb3d317e4c20b4c4bfb19ef97cc4",
+       "model_id": "ff41d42e249e48209fe20f910ce90167",
        "version_major": 2,
        "version_minor": 0
       },
@@ -568,7 +577,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.022035598754882812,
+       "elapsed": 0.029788970947265625,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -582,7 +591,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fb78bbdffc59459183033d7ea524e770",
+       "model_id": "d738add7641440de985f896e11656f86",
        "version_major": 2,
        "version_minor": 0
       },
@@ -610,7 +619,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.024440526962280273,
+       "elapsed": 0.06769466400146484,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -624,7 +633,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3385d5ccdf0f4648afb6ee122b87822e",
+       "model_id": "077a90aaf4124061b2b3a31ef6bddb11",
        "version_major": 2,
        "version_minor": 0
       },
@@ -652,7 +661,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.0373835563659668,
+       "elapsed": 0.05016732215881348,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -666,7 +675,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe9548c42c2049d3921ea7fa1fb4a7ce",
+       "model_id": "cccb3cd0d0ef4269b3d7310147e11872",
        "version_major": 2,
        "version_minor": 0
       },
@@ -844,7 +853,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.037969350814819336,
+       "elapsed": 0.052979469299316406,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -858,7 +867,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6dd8052d4dad4938a7baaca22952a1d7",
+       "model_id": "f59f6b96477f4ede9043a8bbb1050964",
        "version_major": 2,
        "version_minor": 0
       },
@@ -886,7 +895,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.023046493530273438,
+       "elapsed": 0.03510165214538574,
        "initial": 234,
        "n": 234,
        "ncols": null,
@@ -900,7 +909,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "266e40a935a14cf5aadaa5769df822e2",
+       "model_id": "af78eea7ed3c4b00804eead4b218e781",
        "version_major": 2,
        "version_minor": 0
       },
@@ -928,7 +937,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.061977386474609375,
+       "elapsed": 0.02650284767150879,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -942,7 +951,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5b618fd192794dffb951ee21ade7f5eb",
+       "model_id": "cc0b8eea9ea44f7e8925841625a098c3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -970,7 +979,7 @@
        "ascii": false,
        "bar_format": null,
        "colour": null,
-       "elapsed": 0.028913259506225586,
+       "elapsed": 0.022778987884521484,
        "initial": 232,
        "n": 232,
        "ncols": null,
@@ -984,7 +993,7 @@
        "unit_scale": false
       },
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a58eaef056a7410cb3acd8a51cfafb4c",
+       "model_id": "ef2d006b35064ca0b5b39258e6e37f40",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1165,10 +1174,7 @@
     "\n",
     "# Aggregate the naive performance metrics for m1 and m2\n",
     "naive_evals = [naive_eval1, naive_eval2]\n",
-    "naive_eval_df = pd.concat(naive_evals).reset_index(drop=True)\n",
-    "\n",
-    "# Add 'naive' column level in-between yhat1 and metrics levels\n",
-    "naive_eval_df.columns = pd.MultiIndex.from_tuples([(x[0], \"naive\", x[1]) for x in naive_eval_df.columns])"
+    "naive_eval_df = pd.concat(naive_evals).reset_index(drop=True)"
    ]
   },
   {
@@ -1183,10 +1189,7 @@
     "\n",
     "# Aggregate the cqr performance metrics for m1 and m2\n",
     "cqr_evals = [cqr_eval1, cqr_eval2]\n",
-    "cqr_eval_df = pd.concat(cqr_evals).reset_index(drop=True)\n",
-    "\n",
-    "# Add 'cqr' column level in-between yhat1 and metrics levels\n",
-    "cqr_eval_df.columns = pd.MultiIndex.from_tuples([(x[0], \"cqr\", x[1]) for x in cqr_eval_df.columns])"
+    "cqr_eval_df = pd.concat(cqr_evals).reset_index(drop=True)"
    ]
   },
   {
@@ -1199,6 +1202,26 @@
   {
    "cell_type": "code",
    "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop QR from CQR evaluation results as it already exists in Naive\n",
+    "cqr_eval_df = cqr_eval_df.drop(\"qr\", axis=1, level=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Concatenate the naive and cqr evaluation dataframes\n",
+    "eval_df = pd.concat([eval_df, naive_eval_df, cqr_eval_df], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1223,17 +1246,20 @@
        "    <tr>\n",
        "      <th></th>\n",
        "      <th>model</th>\n",
-       "      <th colspan=\"6\" halign=\"left\">yhat1</th>\n",
+       "      <th colspan=\"8\" halign=\"left\">yhat1</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th></th>\n",
        "      <th></th>\n",
+       "      <th colspan=\"2\" halign=\"left\">qr</th>\n",
        "      <th colspan=\"3\" halign=\"left\">naive</th>\n",
        "      <th colspan=\"3\" halign=\"left\">cqr</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th></th>\n",
        "      <th></th>\n",
+       "      <th>interval_width</th>\n",
+       "      <th>miscoverage_rate</th>\n",
        "      <th>qhat1</th>\n",
        "      <th>interval_width</th>\n",
        "      <th>miscoverage_rate</th>\n",
@@ -1246,6 +1272,8 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>m1</td>\n",
+       "      <td>159.782699</td>\n",
+       "      <td>0.482633</td>\n",
        "      <td>160.673025</td>\n",
        "      <td>321.346050</td>\n",
        "      <td>0.107861</td>\n",
@@ -1256,6 +1284,8 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>m2</td>\n",
+       "      <td>21.856230</td>\n",
+       "      <td>0.267368</td>\n",
        "      <td>21.658651</td>\n",
        "      <td>43.317302</td>\n",
        "      <td>0.077895</td>\n",
@@ -1268,27 +1298,25 @@
        "</div>"
       ],
       "text/plain": [
-       "  model       yhat1                                                            \\\n",
-       "              naive                                        cqr                  \n",
-       "              qhat1 interval_width miscoverage_rate      qhat1 interval_width   \n",
-       "0    m1  160.673025     321.346050         0.107861  74.808941     309.400581   \n",
-       "1    m2   21.658651      43.317302         0.077895  11.481231      44.818693   \n",
+       "  model          yhat1                                              \\\n",
+       "                    qr                        naive                  \n",
+       "        interval_width miscoverage_rate       qhat1 interval_width   \n",
+       "0    m1     159.782699         0.482633  160.673025     321.346050   \n",
+       "1    m2      21.856230         0.267368   21.658651      43.317302   \n",
        "\n",
-       "                    \n",
-       "                    \n",
-       "  miscoverage_rate  \n",
-       "0         0.107861  \n",
-       "1         0.071579  "
+       "                                                               \n",
+       "                          cqr                                  \n",
+       "  miscoverage_rate      qhat1 interval_width miscoverage_rate  \n",
+       "0         0.107861  74.808941     309.400581         0.107861  \n",
+       "1         0.077895  11.481231      44.818693         0.071579  "
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Concatenate the naive and cqr evaluation dataframes\n",
-    "eval_df = pd.concat([eval_df, naive_eval_df, cqr_eval_df], axis=1)\n",
     "eval_df"
    ]
   },
@@ -1299,11 +1327,19 @@
     "**Performance of the trained model above**:\n",
     "\n",
     "- This notebook is only using single forecast timestep models, hence we would only have `yhat1` as the point estimator.\n",
-    "- The `interval_width` doubles the quantified uncertainties (`qhat1`) for both the Naive conformal prediction, as such you will be seeing symmetrical prediction intervals.\n",
-    "- The complex model (m2) has a lower *interval width* and *miscoverage rate* than the simple model (m1). The simpler model (m1) have *miscoverage rate* bigger than the confidence level (*alpha* at 0.1) while the complex autoregressioin model (m2) have a *miscoverage rate* smaller than the confidence level. As such, we can conclude that the more complex the model is, the better the data are fitted and the more accurate the prediction are made. \n",
+    "- Both conformal prediction methods (*Naive* and *CQR*), significantly outperforms QR in terms of `miscoverage_rate`.\n",
+    "- The `interval_width` doubles the quantified uncertainties (`qhat1`) for both the Naive conformal predictions, as such you will be seeing symmetrical prediction intervals.\n",
+    "- The complex model (m2) has a lower `interval_width` and `miscoverage_rate` than the simple model (m1). The simpler model (m1) have *miscoverage rate* bigger than the confidence level (*alpha* at 0.1) while the complex autoregressioin model (m2) have a *miscoverage rate* smaller than the confidence level. As such, we can conclude that the more complex the model is, the better the data are fitted and the more accurate the prediction are made. \n",
     "- When we are only looking at the simple quantile regression model (m1), CQR is more preferable as it has narrower prediction *interval width* yet similar *miscoverage rate* than Naive.\n",
     "- As for the complex model (m2), Naive has a slightly better *interval width*, but CQR has a slightly better *miscoverage rate*. You may want to feed the model with more data to determine which method more preferable.\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/feature-use/uncertainty_conformal_prediction.ipynb
+++ b/tutorials/feature-use/uncertainty_conformal_prediction.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "While there are different ways to carry out conformal prediction, NeuralProphet adopts the split conformal prediction, which requires a holdout or calibration set. To carry out split conformal prediction, the dataset has to be split into three distinct sets for training, calibration and testing respectively. An initial prediction interval is created with the base quantile regression model trained by the training dataset. Target variables in the calibration set are being compared to the predicted value, which is denoted as the [quantified uncertainty](https://towardsdatascience.com/conformal-prediction-4775e78b47b6). The final conformal prediction interval is then formed by adding the quantified uncertainty to both tails of the predicted value.\n",
     "\n",
-    "You might select `Naive` (*naive*) or `Conformal Quantile Regression` (*CQR*) for the conformal prediction in NeuralProphet. Here, we illustrate and further elaborate on the conformal prediction naive and CQR module using the hospital electric load dataset. The dataset has recorded the electricity consumption of a hospital in SF in 2015 by hour."
+    "You can select *Naive* (or absolute residual) or *Conformalized Quantile Regression* (or CQR) for the conformal prediction in NeuralProphet. Here, we illustrate and further elaborate on the conformal prediction naive and CQR module using the hospital electric load dataset. The dataset has recorded the electricity consumption of a hospital in SF in 2015 by hour."
    ]
   },
   {
@@ -47,7 +47,6 @@
     "### Data splitting\n",
     "\n",
     "At least three subsets (i.e. testing, calibration and testing) are needed in the conformal prediction feature in NeuralProphet. You may choose to opt in a validation subset in this model. If you want to add in a validation subset to train the base model, please make sure the period of the validation subset must be in between of the training and calibration subsets. In NeuralProphet, there is a data splitting function which divide a dataset input into two subsets. You can configure the function by indicating the time series frequencies and splitting ratio. List of frequency aliases can be found <a href= 'https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases'>here</a>.\n",
-    "\n",
     "\n",
     "In our hospital electric load dataset, we will first divide the original dataset into training and testing set with a train-test ratio of $1/16$ and then further divide the calibation set from the training set with a train-calibration ratio of $1/11$."
    ]
@@ -504,7 +503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After training the base model, we then carry out the calibration process using the naive module. The steps are outlined as follow:\n",
+    "After training the base model, we then carry out the calibration process using the `naive` module. The steps are outlined as follow:\n",
     "<br>i. predict the output value of the instances within the calibration set;\n",
     "<br>ii. calculate absolute residual by comparing the actual and predicted value for each observation in the calibration set;\n",
     "<br>iii. sort all absolute residual in ascending order; and\n",
@@ -819,14 +818,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Option 2: Conformal Quantile Regression"
+    "#### Option 2: Conformalized Quantile Regression"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In [conformal quantile regression (CQR)](https://arxiv.org/abs/1905.03222), the method is run as follows:\n",
+    "In [Conformalized Quantile Regression](https://arxiv.org/abs/1905.03222), or the `cqr` module, the method runs as follows:\n",
     "<br>i. A sorted list of non-conformity scores is calculated as the differences between data points from the calibration dataset and their nearest prediction quantile, which provides a measure of how well the data fits the current quantile regression model.\n",
     "<br>ii. The differences are calculated such they are negative for data points within the quantile regression interval and positive if they are outside the interval.\n",
     "<br>iii. The quantiles from the regression model are adjusted by an amount that satisfies the desired error rate, which is the portion of data points lying outside the interval, based on the calibration data's non-conformity scores."
@@ -1037,7 +1036,7 @@
     }
    ],
    "source": [
-    "# Parameter for conformal quantile regression\n",
+    "# Parameter for Conformalized Quantile Regression\n",
     "method = \"cqr\"\n",
     "\n",
     "# Enable conformal predict on the pre-trained models\n",
@@ -1088,7 +1087,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plot QR forecasts and *CQR* conformal prediction interval with OOS test_df"
+    "Plot *QR* forecasts and *CQR* conformal prediction interval with OOS test_df"
    ]
   },
   {
@@ -1136,8 +1135,8 @@
     "### Evaluate Performance\n",
     "\n",
     "We are using interval width and miscoverage rate as the performance metrics.\n",
-    "- **interval_width**: The average prediction interval, or q_hat multiplied by 2 because it is static or non-adaptive, this is also knowns as the *efficiency* metric.\n",
-    "- **miscoverage_rate**: The actual miscoverage error rate on the OOS test set, this is also knowns as the *validity* metric.\n",
+    "- `interval_width`: The average prediction interval, or q_hat multiplied by 2 because it is static or non-adaptive, this is also knowns as the *efficiency* metric.\n",
+    "- `miscoverage_rate`: The actual miscoverage error rate on the OOS test set, this is also knowns as the *validity* metric.\n",
     "\n",
     "The smaller the metrics are, the better the models are performing.\n",
     "\n",
@@ -1327,11 +1326,11 @@
     "**Performance of the trained model above**:\n",
     "\n",
     "- This notebook is only using single forecast timestep models, hence we would only have `yhat1` as the point estimator.\n",
-    "- Both conformal prediction methods (**Naive** and **CQR**), significantly outperforms vanilla **QR** in terms of `miscoverage_rate`. This shows that the **QR** is *too overconfident* in its quantile values. Hence the `interval_width` needs to be *broadened further* in order for its actual `miscoverage_rate` (on out-of-sample test set) to converge to the specified `alpha` at `0.1` (from calibration set).\n",
-    "- The `interval_width` doubles the quantified uncertainties (`qhat1`) for both the **Naive** conformal predictions, as such you will be seeing symmetrical prediction intervals.\n",
-    "- The complex model (`m2`) has a lower `interval_width` and `miscoverage_rate` than the simple model (`m1`), acroos all uncertainty methods. The simpler model (`m1`) have `miscoverage_rate` bigger than the confidence level (i.e., 90% or 1-`alpha`) while the complex autoregressioin model (`m2`) have a `miscoverage_rate` smaller than the confidence level. As such, we can conclude that *the more complex the model is, the better the data are fitted and the more accurate the prediction are made*. \n",
-    "- When we are only looking at the simple quantile regression model (`m1`), **CQR** is more preferable as it has narrower prediction `interval_width` yet similar `miscoverage_rate` than **Naive**.\n",
-    "- As for the complex model (`m2`), **Naive** has a slightly better `interval_width`, but **CQR** has a slightly better `miscoverage_rate`. You may want to feed the model with more data to determine which method more preferable.\n"
+    "- Both conformal prediction methods (*Naive* and *CQR*), significantly outperforms vanilla *QR* in terms of `miscoverage_rate`. This shows that the *QR* is **too overconfident** in its quantile values. Hence the `interval_width` needs to be **broadened further** in order for its actual `miscoverage_rate` (on out-of-sample test set) to converge to the specified `alpha` at `0.1` (from calibration set).\n",
+    "- The `interval_width` doubles the quantified uncertainties (`qhat1`) for both the *Naive* conformal predictions, as such you will be seeing symmetrical prediction intervals.\n",
+    "- The complex model (`m2`) has a lower `interval_width` and `miscoverage_rate` than the simple model (`m1`), acroos all uncertainty methods. The simpler model (`m1`) have `miscoverage_rate` bigger than the confidence level (i.e., 90% or `1-alpha`) while the complex autoregressioin model (`m2`) have a `miscoverage_rate` smaller than the confidence level. As such, we can conclude that **the more complex the model is, the better the data are fitted and the more accurate the prediction are made**.\n",
+    "- When we are only looking at the simple quantile regression model (`m1`), *CQR* is more preferable as it has narrower prediction `interval_width` yet similar `miscoverage_rate` than *Naive*.\n",
+    "- As for the complex model (`m2`), *Naive* has a slightly better `interval_width`, but *CQR* has a slightly better `miscoverage_rate`. You may want to feed the model with more data to determine which method more preferable.\n"
    ]
   }
  ],


### PR DESCRIPTION
## :microscope: Background

- Added QR so its uncertainty metrics `interval_width` can also be compared to the conformal prediction (CP) metrics.

## :crystal_ball: Key changes

- Included QR into the `uncertainty_evaluate()` method in uncertainty.py.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
