### PR TITLE
[fix] Limit broken dependency versions (mainly pytorch < 2.0)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ pandas>=1.0.4
 plotly>=5.12.0
 plotly_resampler>=0.8.3
 python-dateutil>=2.8.0
-pytorch-lightning>=1.7
+pytorch-lightning>=1.7,<2.0.0
 tensorboard
 torch>=1.8.0,<2.0
 torchmetrics>=0.9.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,7 @@ matplotlib>=2.0.0
 numpy>=1.15.4,<1.24.0
 pandas>=1.0.4
 plotly>=5.12.0
+dash<2.9
 plotly_resampler>=0.8.3
 python-dateutil>=2.8.0
 pytorch-lightning>=1.7,<2.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ plotly_resampler>=0.8.3
 python-dateutil>=2.8.0
 pytorch-lightning>=1.7
 tensorboard
-torch>=1.8.0
+torch>=1.8.0,<2.0
 torchmetrics>=0.9.3
 typing_extensions>=4.4.0;python_version<'3.8'
 widgetsnbextension>=4.0.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,3 +8,4 @@ pytest>=6.2.3
 twine
 wheel
 kaleido==0.2.1
+dash<2.9

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,4 +8,3 @@ pytest>=6.2.3
 twine
 wheel
 kaleido==0.2.1
-dash<2.9


### PR DESCRIPTION
## :microscope: Background

- With the release of pytorch 2.0 our package is broken (for python > 3.7)
- One great example for #911 

## :crystal_ball: Key changes

- Limit version of `pytorch` to `<2.0`
- Limit version of `pytorch-lightning` to `<2.0.0`
- Limit version of `dash` to `<2.9` (dependency of plotly)

## 🚀 How to install

`pip install git+https://github.com/ourownstory/neural_prophet.git@fix-broken-pytorch`

## ⚠️ Unresolved issues
- [x] Github actions fails with a `RuntimeError: wrap_controller at 'pytest_runtest_makereport' /opt/hostedtoolcache/Python/3.7.16/x64/lib/python3.7/site-packages/dash/testing/plugin.py:106 did not yield`
- [x] Had a `AttributeError: 'ProgressBar' object has no attribute 'main_progress_bar'` error locally but could not reproduce it with a new python install

