### PR TITLE
[docs] outdated labels in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ Those prefixed are then used to generate the changelog and decide which version 
 Once your PR needs attention, please add an appropriate label:
 
 - https://github.com/ourownstory/neural_prophet/labels/status%3A%20blocked
+- https://github.com/ourownstory/neural_prophet/labels/status%3A%20in%20development
 - https://github.com/ourownstory/neural_prophet/labels/status%3A%20needs%20review
 - https://github.com/ourownstory/neural_prophet/labels/status%3A%20needs%20update
 - https://github.com/ourownstory/neural_prophet/labels/status%3A%20ready


### PR DESCRIPTION
## :microscope: Background
Labels in contributing.md were outdated, fixes #1241 

## :crystal_ball: Key changes
Added "in development" label