### PR TITLE
[minor] Repeat static trend component n_forecasts times instead of only once

### DIFF
--- a/neuralprophet/components/trend/static.py
+++ b/neuralprophet/components/trend/static.py
@@ -28,7 +28,7 @@ class StaticTrend(Trend):
             torch.Tensor
                 Trend component, same dimensions as input t
         """
-        return self.bias.unsqueeze(dim=0).repeat(t.shape[0], 1, 1)
+        return self.bias.unsqueeze(dim=0).repeat(t.shape[0], self.n_forecasts, 1)
 
     @property
     def get_trend_deltas(self):


### PR DESCRIPTION
## :microscope: Background

Fixes #1168 
The StaticTrend() class (called when growth='off) in static.py does not follow the forecasting pattern of all the other components.
Example: PiecewiseLinear() (when growth not off) forecasts for every sample, and ends up with a shape of (batch_size, n_forecasts, quantiles). Static trend is in shape (batch_size, 1, quantiles). Although the static trend is constant, we need it to be in the same shape as the other components.

## :crystal_ball: Key changes

Repeat static trend component `n_forecasts` times instead of only once to avoid dimension errors

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.