### PR TITLE
[fix] Remove regressor config if all regressors are removed due to unique values 

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -299,7 +299,7 @@ def _check_dataframe(
             checked dataframe
     """
     df, _, _, _ = df_utils.prep_or_copy_df(df)
-    df, regressors_to_remove = df_utils.check_dataframe(
+    df, regressors_to_remove, lag_regressors_to_remove = df_utils.check_dataframe(
         df=df,
         check_y=check_y,
         covariates=model.config_lagged_regressors if exogenous else None,
@@ -312,6 +312,14 @@ def _check_dataframe(
         for reg in regressors_to_remove:
             log.warning(f"Removing regressor {reg} because it is not present in the data.")
             model.config_regressors.pop(reg)
+        if len(model.config_regressors) == 0:
+            model.config_regressors = None
+    if model.config_lagged_regressors is not None:
+        for reg in lag_regressors_to_remove:
+            log.warning(f"Removing lagged regressor {reg} because it is not present in the data.")
+            model.config_lagged_regressors.pop(reg)
+        if len(model.config_lagged_regressors) == 0:
+            model.config_lagged_regressors = None
     return df
 
 

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -521,7 +521,7 @@ def check_dataframe(
     events=None,
     seasonalities=None,
     future: Optional[bool] = None,
-) -> Tuple[pd.DataFrame, List]:
+) -> Tuple[pd.DataFrame, List, List]:
     """Performs basic data sanity checks and ordering,
     as well as prepare dataframe for fitting or predicting.
 

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -556,6 +556,7 @@ def check_dataframe(
         df_aux["ID"] = df_name
         checked_df = pd.concat((checked_df, df_aux), ignore_index=True)
     regressors_to_remove = []
+    lag_regressors_to_remove = []
     if regressors is not None:
         for reg in regressors:
             if len(df[reg].unique()) < 2:
@@ -564,8 +565,6 @@ def check_dataframe(
                     "Automatically removed variable."
                 )
                 regressors_to_remove.append(reg)
-    if future:
-        return checked_df, regressors_to_remove
     if covariates is not None:
         for covar in covariates:
             if len(df[covar].unique()) < 2:
@@ -573,12 +572,18 @@ def check_dataframe(
                     "Encountered lagged regressor with only unique values in training set across all IDs."
                     "Automatically removed variable."
                 )
-                regressors_to_remove.append(covar)
+                lag_regressors_to_remove.append(covar)
+    if future:
+        return checked_df, regressors_to_remove, lag_regressors_to_remove
     if len(regressors_to_remove) > 0:
         regressors_to_remove = list(set(regressors_to_remove))
-        checked_df = checked_df.drop(*regressors_to_remove, axis=1)
+        checked_df = checked_df.drop(regressors_to_remove, axis=1)
         assert checked_df is not None
-    return checked_df, regressors_to_remove
+    if len(lag_regressors_to_remove) > 0:
+        lag_regressors_to_remove = list(set(lag_regressors_to_remove))
+        checked_df = checked_df.drop(lag_regressors_to_remove, axis=1)
+        assert checked_df is not None
+    return checked_df, regressors_to_remove, lag_regressors_to_remove
 
 
 def _crossvalidation_split_df(df, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct=0.0):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1644,5 +1644,5 @@ def test_unused_future_regressors():
     )
     m = NeuralProphet(epochs=1, learning_rate=0.01)
     m.add_future_regressor("price")
-    m.add_future_regressor("cost")
+    m.add_lagged_regressor("cost")
     m.fit(df, freq="D")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -49,7 +49,7 @@ def test_train_eval_test():
         learning_rate=LR,
     )
     df = pd.read_csv(PEYTON_FILE, nrows=95)
-    df, _ = df_utils.check_dataframe(df, check_y=False)
+    df, _, _ = df_utils.check_dataframe(df, check_y=False)
     df = _handle_missing_data(m, df, freq="D", predicting=False)
     df_train, df_test = m.split_df(df, freq="D", valid_p=0.1)
     metrics = m.fit(df_train, freq="D", validation_df=df_test)
@@ -61,7 +61,7 @@ def test_train_eval_test():
 def test_df_utils_func():
     log.info("testing: df_utils Test")
     df = pd.read_csv(PEYTON_FILE, nrows=95)
-    df, _ = df_utils.check_dataframe(df, check_y=False)
+    df, _, _ = df_utils.check_dataframe(df, check_y=False)
 
     # test find_time_threshold
     df, _, _, _ = df_utils.prep_or_copy_df(df)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1631,3 +1631,18 @@ def test_selective_forecasting():
     )
     metrics_df = m.fit(df, freq="H")
     forecast = m.predict(df)
+
+
+def test_unused_future_regressors():
+    df = pd.DataFrame(
+        {
+            "ds": {0: "2022-10-16 00:00:00", 1: "2022-10-17 00:00:00", 2: "2022-10-18 00:00:00"},
+            "y": {0: 17, 1: 18, 2: 10},
+            "price": {0: 3.5, 1: 3.5, 2: 3.5},
+            "cost": {0: 2.5, 1: 2.5, 2: 2.5},
+        }
+    )
+    m = NeuralProphet(epochs=1)
+    m.add_future_regressor("price")
+    m.add_future_regressor("cost")
+    m.fit(df, freq="D")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1642,7 +1642,7 @@ def test_unused_future_regressors():
             "cost": {0: 2.5, 1: 2.5, 2: 2.5},
         }
     )
-    m = NeuralProphet(epochs=1)
+    m = NeuralProphet(epochs=1, learning_rate=0.01)
     m.add_future_regressor("price")
     m.add_future_regressor("cost")
     m.fit(df, freq="D")

--- a/tests/test_regularization.py
+++ b/tests/test_regularization.py
@@ -57,7 +57,7 @@ def test_reg_func_abs():
 def test_regularization_holidays():
     log.info("testing: regularization of holidays")
     df = generate_holiday_dataset(y_holidays_override=Y_HOLIDAYS_OVERRIDE)
-    df, _ = df_utils.check_dataframe(df, check_y=False)
+    df, _, _ = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(
         epochs=20,
@@ -89,7 +89,7 @@ def test_regularization_holidays():
 def test_regularization_events():
     log.info("testing: regularization of events")
     df, events = generate_event_dataset(y_events_override=Y_EVENTS_OVERRIDE)
-    df, _ = df_utils.check_dataframe(df, check_y=False)
+    df, _, _ = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(
         epochs=50,
@@ -141,7 +141,7 @@ def test_regularization_lagged_regressor():
     """
     log.info("testing: regularization lagged regressors")
     df, lagged_regressors = generate_lagged_regressor_dataset(periods=100)
-    df, _ = df_utils.check_dataframe(df, check_y=False)
+    df, _, _ = df_utils.check_dataframe(df, check_y=False)
 
     m = NeuralProphet(
         epochs=30,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -78,7 +78,7 @@ def test_time_dataset():
     config_missing = configure.MissingDataHandling()
     df_train, df_val = df_utils.split_df(df_in, n_lags, n_forecasts, valid_p)
     # create a tabularized dataset from time series
-    df, _ = df_utils.check_dataframe(df_train)
+    df, _, _ = df_utils.check_dataframe(df_train)
     local_data_params, global_data_params = df_utils.init_data_params(df=df, normalize="minmax")
     df = df.drop("ID", axis=1)
     df = df_utils.normalize(df, global_data_params)
@@ -218,7 +218,7 @@ def test_split_impute():
             n_lags=n_lags,
             n_forecasts=n_forecasts,
         )
-        df_in, _ = df_utils.check_dataframe(df_in, check_y=False)
+        df_in, _, _ = df_utils.check_dataframe(df_in, check_y=False)
         df_in = _handle_missing_data(m, df_in, freq=freq, predicting=False)
         assert df_len_expected == len(df_in)
         total_samples = len(df_in) - n_lags - 2 * n_forecasts + 2
@@ -816,7 +816,7 @@ def test_too_many_NaN():
         limit_linear=config_missing.impute_linear,
         rolling=config_missing.impute_rolling,
     )
-    df, _ = df_utils.check_dataframe(df)
+    df, _, _ = df_utils.check_dataframe(df)
     local_data_params, global_data_params = df_utils.init_data_params(df=df, normalize="minmax")
     df = df.drop("ID", axis=1)
     df = df_utils.normalize(df, global_data_params)


### PR DESCRIPTION
## :microscope: Background

Fixes #1227 
Closes #1250 
In the case of only having unique values for future (or lagged) regressors, we currently remove the regressor column from the data. However, the `config_regressor` still survives (although being empty), which causes an error. 

## :crystal_ball: Key changes

In the event of all future (or lagged) regressors are removed due to only having single values in the column, the fitting and predicting procedure runs through without considering any regressors (i.e. the model is trained as if no regressors would have been specified). 

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.