### PR TITLE
[minor] Address warnings

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -123,7 +123,7 @@ def _reshape_raw_predictions_to_forecst_df(model, df, predicted, components, pre
                     dates_comp = pd.Series(date_list[0])
                     for i in range(1, len(date_list)):
                         dates_comp = dates_comp[dates_comp.isin(date_list[i])]
-                    ser = pd.Series()
+                    ser = pd.Series(dtype="datetime64[ns]")
                     for date in dates_comp:
                         d = pd.date_range(date, periods=model.n_forecasts + 1, freq=model.data_freq)
                         ser = pd.concat((ser, pd.Series(d).iloc[1:]))


### PR DESCRIPTION
## :microscope: Background
Some warnings could be fixed, fixes https://github.com/ourownstory/neural_prophet/issues/1159

## :crystal_ball: Key changes
**Fixed warnings**
- [x] test_integration.py: neuralprophet/data/process.py:126: DeprecationWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.

**Not addressed and reason**
- [x] neural_prophet/.venv/lib/python3.9/site-packages/plotly_resampler/aggregation/aggregators.py:25: UserWarning: Could not import lttbc; will use a (slower) python alternative.
    warnings.warn("Could not import lttbc; will use a (slower) python alternative.") 
--> will be removed in the near future, see https://github.com/predict-idlab/plotly-resampler/issues/180
- [x] torch: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead. 
--> is already fixed in torch 2.0, see here for the commit, that fixes it: https://github.com/pytorch/pytorch/pull/95545 (merged on Feb 27)
- [x] DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('pytorch_lightning')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    __import__("pkg_resources").declare_namespace(__name__)
--> Lightning knows about the warning and are on it, see https://github.com/Lightning-AI/lightning/issues/16756

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.
