### PR TITLE
[fix] unregister plotly resampler directly after usage

### DIFF
--- a/neuralprophet/plot_forecast_plotly.py
+++ b/neuralprophet/plot_forecast_plotly.py
@@ -226,6 +226,7 @@ def plot(
         **layout_args,
     )
     fig = go.Figure(data=data, layout=layout)
+    unregister_plotly_resampler()
     return fig
 
 
@@ -337,6 +338,7 @@ def plot_components(
     # Reset multiplicative axes labels after tight_layout adjustment
     for ax in multiplicative_axes:
         ax = set_y_as_percent(ax)
+    unregister_plotly_resampler()
     return fig
 
 
@@ -814,6 +816,7 @@ def plot_nonconformity_scores(scores, alpha, q, method, resampler_active=False):
             line_color="red",
         )
         fig.update_layout(margin=dict(l=70, r=70, t=60, b=50))
+        unregister_plotly_resampler()
         return fig
 
 
@@ -873,4 +876,5 @@ def plot_interval_width_per_timestep(q_hats, method, resampler_active=False):
             height=400,
         )
     fig.update_layout(margin=dict(l=70, r=70, t=60, b=50))
+    unregister_plotly_resampler()
     return fig

--- a/neuralprophet/plot_model_parameters_plotly.py
+++ b/neuralprophet/plot_model_parameters_plotly.py
@@ -955,5 +955,5 @@ def plot_parameters(
         yaxis.update(**yaxis_args)
         for trace in trace_object["traces"]:
             fig.add_trace(trace, row=i + 1, col=1)  # adapt var name to plotly-resampler
-
+        unregister_plotly_resampler()
     return fig


### PR DESCRIPTION
## :microscope: Background

The` plotly_resampler` has not been unregistered after usage. That causes an error when plotting a `go.Figure `while having `neuralprophet `imported. 

## :crystal_ball: Key changes

- unregister `plotly_resampler` after every function call of a plotting function before it returns the `fig`. 
- info: `plotly_resampler `functionality s not affected by it.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- N.A. [ ] I have commented my code, added docstrings and data types to function definitions.
- N.A. [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
