### PR TITLE
[minor] lighten forecaster step 2 - encapsulate _get_maybe_extend_periods and _maybe_extend_df

### DIFF
--- a/neuralprophet/data/split.py
+++ b/neuralprophet/data/split.py
@@ -16,7 +16,7 @@ def _maybe_extend_df(
     df: pd.DataFrame,
     n_forecasts: int,
     max_lags: int,
-    freq: str,
+    freq: Optional[str],
     config_regressors: Optional[OrderedDictType[str, Regressor]],
     config_events: Optional[ConfigEvents],
 ) -> Tuple[pd.DataFrame, dict]:

--- a/neuralprophet/data/split.py
+++ b/neuralprophet/data/split.py
@@ -1,5 +1,7 @@
 import logging
+from typing import Optional
 from typing import OrderedDict as OrderedDictType
+from typing import Tuple
 
 import pandas as pd
 
@@ -15,9 +17,33 @@ def _maybe_extend_df(
     n_forecasts: int,
     max_lags: int,
     freq: str,
-    config_regressors: OrderedDictType[str, Regressor],
-    config_events: ConfigEvents,
-):
+    config_regressors: Optional[OrderedDictType[str, Regressor]],
+    config_events: Optional[ConfigEvents],
+) -> Tuple[pd.DataFrame, dict]:
+    """
+    Extend the input DataFrame based on the number of forecasts, maximum lags,
+    frequency, regressor configuration, and event configuration.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input DataFrame to be extended.
+    n_forecasts : int
+        Number of forecasts to be made.
+    max_lags : int
+        Number of steps ahead of prediction time step to forecast.
+    freq : str
+        Frequency of the time series data.
+    config_regressors : OrderedDict[str, Regressor]
+        Configuration of regressors.
+    config_events : ConfigEvents
+        Configuration of events.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, int]
+        A tuple containing the extended DataFrame and the periods added.
+    """
     # Receives df with ID column
     periods_add = {}
     extended_df = pd.DataFrame()
@@ -49,8 +75,39 @@ def _get_maybe_extend_periods(
     df: pd.DataFrame,
     n_forecasts: int,
     max_lags: int,
-    config_regressors: OrderedDictType[str, Regressor],
-):
+    config_regressors: Optional[OrderedDictType[str, Regressor]],
+) -> int:
+    """
+    Determine the number of periods to extend the input DataFrame based on the
+    number of forecasts, maximum lags, and regressor configuration.
+
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input DataFrame with a single ID column.
+    n_forecasts : int
+        Number of steps ahead of prediction time step to forecast.
+    max_lags : int
+        Maximum number of lags to consider.
+    config_regressors : OrderedDictType[str, Regressor]
+        Configuration of regressors. If None, the function may extend the
+        DataFrame based on `n_forecasts` and `max_lags`.
+
+    Returns
+    -------
+    int
+        Number of periods to extend the input DataFrame.
+
+    Raises
+    ------
+    AssertionError
+        If the input DataFrame contains more than one unique ID.
+
+    Notes
+    -----
+    The function assumes that the input DataFrame contains columns 'ID' and 'y'.
+    """
     # Receives df with single ID column
     assert len(df["ID"].unique()) == 1
     periods_add = 0

--- a/neuralprophet/data/split.py
+++ b/neuralprophet/data/split.py
@@ -1,14 +1,23 @@
 import logging
+from typing import OrderedDict as OrderedDictType
 
 import pandas as pd
 
 from neuralprophet import df_utils
+from neuralprophet.configure import ConfigEvents, Regressor
 from neuralprophet.data.process import _check_dataframe
 
 log = logging.getLogger("NP.data.splitting")
 
 
-def _maybe_extend_df(df, n_forecasts, n_lags, max_lags, freq, config_regressors, config_events):  # model.data_freq
+def _maybe_extend_df(
+    df: pd.DataFrame,
+    n_forecasts: int,
+    max_lags: int,
+    freq: str,
+    config_regressors: OrderedDictType[str, Regressor],
+    config_events: ConfigEvents,
+):
     # Receives df with ID column
     periods_add = {}
     extended_df = pd.DataFrame()
@@ -36,7 +45,12 @@ def _maybe_extend_df(df, n_forecasts, n_lags, max_lags, freq, config_regressors,
     return extended_df, periods_add
 
 
-def _get_maybe_extend_periods(df, n_forecasts, max_lags, config_regressors):
+def _get_maybe_extend_periods(
+    df: pd.DataFrame,
+    n_forecasts: int,
+    max_lags: int,
+    config_regressors: OrderedDictType[str, Regressor],
+):
     # Receives df with single ID column
     assert len(df["ID"].unique()) == 1
     periods_add = 0

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -992,7 +992,6 @@ class NeuralProphet:
         df, periods_added = _maybe_extend_df(
             df=df,
             n_forecasts=self.n_forecasts,
-            n_lags=self.n_lags,
             max_lags=self.max_lags,
             freq=self.data_freq,
             config_regressors=self.config_regressors,

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -989,7 +989,15 @@ class NeuralProphet:
             raise ValueError("Model has not been fitted. Predictions will be random.")
         df, received_ID_col, received_single_time_series, _ = df_utils.prep_or_copy_df(df)
         # to get all forecasteable values with df given, maybe extend into future:
-        df, periods_added = _maybe_extend_df(self, df)
+        df, periods_added = _maybe_extend_df(
+            df=df,
+            n_forecasts=self.n_forecasts,
+            n_lags=self.n_lags,
+            max_lags=self.max_lags,
+            freq=self.data_freq,
+            config_regressors=self.config_regressors,
+            config_events=self.config_events,
+        )
         df = _prepare_dataframe_to_predict(self, df)
         # normalize
         df = _normalize(self, df)


### PR DESCRIPTION
## :microscope: Background

Related to #1133
This PR is part of a series of PRs belonging to **step 2 of restructuring the `forecaster.py`**. Step 1 was to move identified functions out of the forecaster.py into dedicated files. Step 2 is to encapsulate the input arguments of the moved functions. Step2 will be implemented step-by-step within multiple PRs

## :crystal_ball: Key changes

- Encapsulate `_get_maybe_extend_periods` and `_maybe_extend_df`

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- N.A. [ ] I have commented my code, added docstrings and data types to function definitions.
- N.A. [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
