### PR TITLE
[refactor] Encapsulate _normalize

### DIFF
--- a/neuralprophet/data/transform.py
+++ b/neuralprophet/data/transform.py
@@ -3,11 +3,12 @@ import logging
 import pandas as pd
 
 from neuralprophet import df_utils
+from neuralprophet.configure import Normalization
 
 log = logging.getLogger("NP.data.transforming")
 
 
-def _normalize(model, df):
+def _normalize(df: pd.DataFrame, config_normalization: Normalization) -> pd.DataFrame:
     """Apply data scales.
 
     Applies data scaling factors to df using data_params.
@@ -16,6 +17,8 @@ def _normalize(model, df):
     ----------
         df : pd.DataFrame
             dataframe containing column ``ds``, ``y``, and optionally``ID`` with all data
+        config_normalization: Normalization
+            Normalization configuration
 
     Returns
     -------
@@ -24,7 +27,7 @@ def _normalize(model, df):
     df, _, _, _ = df_utils.prep_or_copy_df(df)
     df_norm = pd.DataFrame()
     for df_name, df_i in df.groupby("ID"):
-        data_params = model.config_normalization.get_data_params(df_name)
+        data_params = config_normalization.get_data_params(df_name)
         df_i.drop("ID", axis=1, inplace=True)
         df_aux = df_utils.normalize(df_i, data_params).copy(deep=True)
         df_aux["ID"] = df_name

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -999,7 +999,7 @@ class NeuralProphet:
         )
         df = _prepare_dataframe_to_predict(self, df)
         # normalize
-        df = _normalize(self, df)
+        df = _normalize(df=df, config_normalization=self.config_normalization)
         forecast = pd.DataFrame()
         for df_name, df_i in df.groupby("ID"):
             dates, predicted, components = self._predict_raw(
@@ -1577,7 +1577,7 @@ class NeuralProphet:
 
         df, received_ID_col, received_single_time_series, _ = df_utils.prep_or_copy_df(df)
         df = _check_dataframe(self, df, check_y=False, exogenous=False)
-        df = _normalize(self, df)
+        df = _normalize(df=df, config_normalization=self.config_normalization)
         df_trend = pd.DataFrame()
         for df_name, df_i in df.groupby("ID"):
             t = torch.from_numpy(np.expand_dims(df_i["t"].values, 1))  # type: ignore
@@ -1621,7 +1621,7 @@ class NeuralProphet:
 
         df, received_ID_col, received_single_time_series, _ = df_utils.prep_or_copy_df(df)
         df = _check_dataframe(self, df, check_y=False, exogenous=False)
-        df = _normalize(self, df)
+        df = _normalize(df=df, config_normalization=self.config_normalization)
         df_seasonal = pd.DataFrame()
         for df_name, df_i in df.groupby("ID"):
             dataset = time_dataset.TimeDataset(
@@ -2380,12 +2380,12 @@ class NeuralProphet:
             config_seasonality=self.config_seasonality,
         )
 
-        df = _normalize(self, df)
+        df = _normalize(df=df, config_normalization=self.config_normalization)
         # if not self.fitted:
         if self.config_trend.changepoints is not None:
             # scale user-specified changepoint times
             df_aux = pd.DataFrame({"ds": pd.Series(self.config_trend.changepoints)})
-            self.config_trend.changepoints = _normalize(self, df_aux)["t"].values  # type: ignore # types are numpy.ArrayLike and list
+            self.config_trend.changepoints = _normalize(df=df_aux, config_normalization=self.config_normalization)["t"].values  # type: ignore # types are numpy.ArrayLike and list
 
         # df_merged, _ = df_utils.join_dataframes(df)
         # df_merged = df_merged.sort_values("ds")
@@ -2419,7 +2419,7 @@ class NeuralProphet:
             torch DataLoader
         """
         df, _, _, _ = df_utils.prep_or_copy_df(df)
-        df = _normalize(self, df)
+        df = _normalize(df=df, config_normalization=self.config_normalization)
         dataset = _create_dataset(self, df, predict_mode=False)
         loader = DataLoader(dataset, batch_size=min(1024, len(dataset)), shuffle=False, drop_last=False)
         return loader

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -109,9 +109,9 @@ def test_normalize():
     df, _, _, _ = df_utils.prep_or_copy_df(df)
     # with config
     m.config_normalization.init_data_params(df, m.config_lagged_regressors, m.config_regressors, m.config_events)
-    df_norm = _normalize(m, df)
+    df_norm = _normalize(df=df, config_normalization=m.config_normalization)
     m.config_normalization.unknown_data_normalization = True
-    df_norm = _normalize(m, df)
+    df_norm = _normalize(df=df, config_normalization=m.config_normalization)
     m.config_normalization.unknown_data_normalization = False
     # using config for utils
     df = df.drop("ID", axis=1)
@@ -646,7 +646,7 @@ def test_globaltimedataset():
             df_global, m.config_lagged_regressors, m.config_regressors, m.config_events
         )
         m.config_normalization = config_normalization
-        df_global = _normalize(m, df_global)
+        df_global = _normalize(df=df_global, config_normalization=m.config_normalization)
         dataset = _create_dataset(m, df_global, predict_mode=False)
         dataset = _create_dataset(m, df_global, predict_mode=True)
 
@@ -669,7 +669,7 @@ def test_globaltimedataset():
         df4
         config_normalization.init_data_params(df4, m.config_lagged_regressors, m.config_regressors, m.config_events)
         m.config_normalization = config_normalization
-        df4 = _normalize(m, df4)
+        df4 = _normalize(df=df4, config_normalization=m.config_normalization)
         dataset = _create_dataset(m, df4, predict_mode=False)
         dataset = _create_dataset(m, df4, predict_mode=True)
 
@@ -699,7 +699,7 @@ def test_dataloader():
     df_global["ds"] = pd.to_datetime(df_global.loc[:, "ds"])
     config_normalization.init_data_params(df_global, m.config_lagged_regressors, m.config_regressors, m.config_events)
     m.config_normalization = config_normalization
-    df_global = _normalize(m, df_global)
+    df_global = _normalize(df=df_global, config_normalization=m.config_normalization)
     dataset = _create_dataset(m, df_global, predict_mode=False)
     loader = DataLoader(dataset, batch_size=min(1024, len(df)), shuffle=True, drop_last=False)
     for inputs, targets, meta in loader:


### PR DESCRIPTION
## :microscope: Background

Related to #1133
This PR is part of a series of PRs belonging to **step 2 of restructuring the `forecaster.py`**. Step 1 was to move identified functions out of the forecaster.py into dedicated files. Step 2 is to encapsulate the input arguments of the moved functions. Step2 will be implemented step-by-step within multiple PRs

## :crystal_ball: Key changes

- Encapsulate `_normalize` including docstring and typing

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- N.A. [ ] I have commented my code, added docstrings and data types to function definitions.
- N.A. [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).