### PR TITLE
[refactor] Encapsulate _handle_missing_data and _handle_missing_data_single_id

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -890,7 +890,18 @@ class NeuralProphet:
         df, _, _, self.id_list = df_utils.prep_or_copy_df(df)
         df = _check_dataframe(self, df, check_y=True, exogenous=True)
         self.data_freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq)
-        df = _handle_missing_data(self, df, freq=self.data_freq)
+        df = _handle_missing_data(
+            df=df,
+            freq=self.data_freq,
+            n_lags=self.n_lags,
+            n_forecasts=self.n_forecasts,
+            config_missing=self.config_missing,
+            config_regressors=self.config_regressors,
+            config_lagged_regressors=self.config_lagged_regressors,
+            config_events=self.config_events,
+            config_seasonality=self.config_seasonality,
+            predicting=False,
+        )
 
         # Setup for global-local modelling: If there is only a single time series, then self.id_list = ['__df__']
         self.num_trends_modelled = len(self.id_list) if self.config_trend.trend_global_local == "local" else 1
@@ -921,7 +932,18 @@ class NeuralProphet:
         else:
             df_val, _, _, _ = df_utils.prep_or_copy_df(validation_df)
             df_val = _check_dataframe(self, df_val, check_y=False, exogenous=False)
-            df_val = _handle_missing_data(self, df_val, freq=self.data_freq)
+            df_val = _handle_missing_data(
+                df=df_val,
+                freq=self.data_freq,
+                n_lags=self.n_lags,
+                n_forecasts=self.n_forecasts,
+                config_missing=self.config_missing,
+                config_regressors=self.config_regressors,
+                config_lagged_regressors=self.config_lagged_regressors,
+                config_events=self.config_events,
+                config_seasonality=self.config_seasonality,
+                predicting=False,
+            )
             metrics_df = self._train(
                 df,
                 df_val=df_val,
@@ -1040,7 +1062,18 @@ class NeuralProphet:
             log.warning("Model has not been fitted. Test results will be random.")
         df = _check_dataframe(self, df, check_y=True, exogenous=True)
         _ = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=self.data_freq)
-        df = _handle_missing_data(self, df, freq=self.data_freq)
+        df = _handle_missing_data(
+            df=df,
+            freq=self.data_freq,
+            n_lags=self.n_lags,
+            n_forecasts=self.n_forecasts,
+            config_missing=self.config_missing,
+            config_regressors=self.config_regressors,
+            config_lagged_regressors=self.config_lagged_regressors,
+            config_events=self.config_events,
+            config_seasonality=self.config_seasonality,
+            predicting=False,
+        )
         loader = self._init_val_loader(df)
         # Use Lightning to calculate metrics
         val_metrics = self.trainer.test(self.model, dataloaders=loader)
@@ -1165,7 +1198,18 @@ class NeuralProphet:
         df, received_ID_col, received_single_time_series, _ = df_utils.prep_or_copy_df(df)
         df = _check_dataframe(self, df, check_y=False, exogenous=False)
         freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq)
-        df = _handle_missing_data(self, df, freq=freq, predicting=False)
+        df = _handle_missing_data(
+            df=df,
+            freq=self.data_freq,
+            n_lags=self.n_lags,
+            n_forecasts=self.n_forecasts,
+            config_missing=self.config_missing,
+            config_regressors=self.config_regressors,
+            config_lagged_regressors=self.config_lagged_regressors,
+            config_events=self.config_events,
+            config_seasonality=self.config_seasonality,
+            predicting=False,
+        )
         df_train, df_val = df_utils.split_df(
             df,
             n_lags=self.max_lags,
@@ -1333,7 +1377,18 @@ class NeuralProphet:
         df, received_ID_col, received_single_time_series, _ = df_utils.prep_or_copy_df(df)
         df = _check_dataframe(self, df, check_y=False, exogenous=False)
         freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq)
-        df = _handle_missing_data(self, df, freq=freq, predicting=False)
+        df = _handle_missing_data(
+            df=df,
+            freq=self.data_freq,
+            n_lags=self.n_lags,
+            n_forecasts=self.n_forecasts,
+            config_missing=self.config_missing,
+            config_regressors=self.config_regressors,
+            config_lagged_regressors=self.config_lagged_regressors,
+            config_events=self.config_events,
+            config_seasonality=self.config_seasonality,
+            predicting=False,
+        )
         folds = df_utils.crossvalidation_split_df(
             df,
             n_lags=self.max_lags,
@@ -1385,7 +1440,18 @@ class NeuralProphet:
         df, _, _, _ = df_utils.prep_or_copy_df(df)
         df = _check_dataframe(self, df, check_y=False, exogenous=False)
         freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq)
-        df = _handle_missing_data(self, df, freq=freq, predicting=False)
+        df = _handle_missing_data(
+            df=df,
+            freq=self.data_freq,
+            n_lags=self.n_lags,
+            n_forecasts=self.n_forecasts,
+            config_missing=self.config_missing,
+            config_regressors=self.config_regressors,
+            config_lagged_regressors=self.config_lagged_regressors,
+            config_events=self.config_events,
+            config_seasonality=self.config_seasonality,
+            predicting=False,
+        )
         folds_val, folds_test = df_utils.double_crossvalidation_split_df(
             df,
             n_lags=self.max_lags,

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1061,10 +1061,10 @@ class NeuralProphet:
         if self.fitted is False:
             log.warning("Model has not been fitted. Test results will be random.")
         df = _check_dataframe(self, df, check_y=True, exogenous=True)
-        _ = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=self.data_freq)
+        freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=self.data_freq)
         df = _handle_missing_data(
             df=df,
-            freq=self.data_freq,
+            freq=freq,
             n_lags=self.n_lags,
             n_forecasts=self.n_forecasts,
             config_missing=self.config_missing,
@@ -1200,7 +1200,7 @@ class NeuralProphet:
         freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq)
         df = _handle_missing_data(
             df=df,
-            freq=self.data_freq,
+            freq=freq,
             n_lags=self.n_lags,
             n_forecasts=self.n_forecasts,
             config_missing=self.config_missing,
@@ -1379,7 +1379,7 @@ class NeuralProphet:
         freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq)
         df = _handle_missing_data(
             df=df,
-            freq=self.data_freq,
+            freq=freq,
             n_lags=self.n_lags,
             n_forecasts=self.n_forecasts,
             config_missing=self.config_missing,
@@ -1442,7 +1442,7 @@ class NeuralProphet:
         freq = df_utils.infer_frequency(df, n_lags=self.max_lags, freq=freq)
         df = _handle_missing_data(
             df=df,
-            freq=self.data_freq,
+            freq=freq,
             n_lags=self.n_lags,
             n_forecasts=self.n_forecasts,
             config_missing=self.config_missing,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -50,7 +50,18 @@ def test_train_eval_test():
     )
     df = pd.read_csv(PEYTON_FILE, nrows=95)
     df, _, _ = df_utils.check_dataframe(df, check_y=False)
-    df = _handle_missing_data(m, df, freq="D", predicting=False)
+    df_in = _handle_missing_data(
+        df=df,
+        freq="D",
+        n_lags=m.n_lags,
+        n_forecasts=m.n_forecasts,
+        config_missing=m.config_missing,
+        config_regressors=m.config_regressors,
+        config_lagged_regressors=m.config_lagged_regressors,
+        config_events=m.config_events,
+        config_seasonality=m.config_seasonality,
+        predicting=False,
+    )
     df_train, df_test = m.split_df(df, freq="D", valid_p=0.1)
     metrics = m.fit(df_train, freq="D", validation_df=df_test)
     val_metrics = m.test(df_test)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -219,7 +219,18 @@ def test_split_impute():
             n_forecasts=n_forecasts,
         )
         df_in, _, _ = df_utils.check_dataframe(df_in, check_y=False)
-        df_in = _handle_missing_data(m, df_in, freq=freq, predicting=False)
+        df_in = _handle_missing_data(
+            df=df_in,
+            freq=freq,
+            n_lags=n_lags,
+            n_forecasts=n_forecasts,
+            config_missing=m.config_missing,
+            config_regressors=m.config_regressors,
+            config_lagged_regressors=m.config_lagged_regressors,
+            config_events=m.config_events,
+            config_seasonality=m.config_seasonality,
+            predicting=False,
+        )
         assert df_len_expected == len(df_in)
         total_samples = len(df_in) - n_lags - 2 * n_forecasts + 2
         df_train, df_test = m.split_df(df_in, freq=freq, valid_p=0.1)


### PR DESCRIPTION
## :microscope: Background

Related to #1133
This PR is part of a series of PRs belonging to **step 2 of restructuring the `forecaster.py`**. Step 1 was to move identified functions out of the forecaster.py into dedicated files. Step 2 is to encapsulate the input arguments of the moved functions. Step2 will be implemented step-by-step within multiple PRs

## :crystal_ball: Key changes

- Encapsulate `_handle_missing_data ` including docstring and typing
- Rename and encapsulate `_handle_missing_data_single_id` including docstring and typing

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- N.A. [ ] I have commented my code, added docstrings and data types to function definitions.
- N.A. [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).