### PR TITLE
[refactor] Encapsulate _validate_column_name

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -5,6 +5,13 @@ import numpy as np
 import pandas as pd
 
 from neuralprophet import df_utils, time_dataset
+from neuralprophet.configure import (
+    ConfigCountryHolidays,
+    ConfigEvents,
+    ConfigFutureRegressors,
+    ConfigLaggedRegressors,
+    ConfigSeasonality,
+)
 
 log = logging.getLogger("NP.data.processing")
 
@@ -214,19 +221,42 @@ def _prepare_dataframe_to_predict(model, df):
     return df_prepared
 
 
-def _validate_column_name(model, name, events=True, seasons=True, regressors=True, covariates=True):
+def _validate_column_name(
+    name: str,
+    config_events: Optional[ConfigEvents],
+    config_country_holidays: Optional[ConfigCountryHolidays],
+    config_seasonality: Optional[ConfigSeasonality],
+    config_lagged_regressors: Optional[ConfigLaggedRegressors],
+    config_regressors: Optional[ConfigFutureRegressors],
+    events: Optional[bool] = True,
+    seasons: Optional[bool] = True,
+    regressors: Optional[bool] = True,
+    covariates: Optional[bool] = True,
+):
     """Validates the name of a seasonality, event, or regressor.
 
     Parameters
     ----------
         name : str
             name of seasonality, event or regressor
+        config_events : Optional[ConfigEvents]
+            Configuration options for adding events to the model.
+        config_country_holidays : Optional[ConfigCountryHolidays]
+            Configuration options for adding country holidays to the model.
+        config_seasonality : Optional[ConfigSeasonality]
+            Configuration options for adding seasonal components to the model.
+        config_lagged_regressors : Optional[ConfigLaggedRegressors]
+            Configuration options for adding lagged external regressors to the model.
+        config_regressors : Optional[ConfigFutureRegressors]
+            Configuration options for adding future regressors to the model.
         events : bool
             check if name already used for event
         seasons : bool
             check if name already used for seasonality
         regressors : bool
             check if name already used for regressor
+        covariates : bool
+            check if name already used for covariate
     """
     reserved_names = [
         "trend",
@@ -250,20 +280,20 @@ def _validate_column_name(model, name, events=True, seasons=True, regressors=Tru
     reserved_names.extend(["ds", "y", "cap", "floor", "y_scaled", "cap_scaled"])
     if name in reserved_names:
         raise ValueError(f"Name {name!r} is reserved.")
-    if events and model.config_events is not None:
-        if name in model.config_events.keys():
+    if events and config_events is not None:
+        if name in config_events.keys():
             raise ValueError(f"Name {name!r} already used for an event.")
-    if events and model.config_country_holidays is not None:
-        if name in model.config_country_holidays.holiday_names:
-            raise ValueError(f"Name {name!r} is a holiday name in {model.config_country_holidays.country}.")
-    if seasons and model.config_seasonality is not None:
-        if name in model.config_seasonality.periods:
+    if events and config_country_holidays is not None:
+        if name in config_country_holidays.holiday_names:
+            raise ValueError(f"Name {name!r} is a holiday name in {config_country_holidays.country}.")
+    if seasons and config_seasonality is not None:
+        if name in config_seasonality.periods:
             raise ValueError(f"Name {name!r} already used for a seasonality.")
-    if covariates and model.config_lagged_regressors is not None:
-        if name in model.config_lagged_regressors:
+    if covariates and config_lagged_regressors is not None:
+        if name in config_lagged_regressors:
             raise ValueError(f"Name {name!r} already used for an added covariate.")
-    if regressors and model.config_regressors is not None:
-        if name in model.config_regressors.keys():
+    if regressors and config_regressors is not None:
+        if name in config_regressors.keys():
             raise ValueError(f"Name {name!r} already used for an added regressor.")
 
 

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -537,7 +537,14 @@ class NeuralProphet:
         if not isinstance(names, list):
             names = [names]
         for name in names:
-            _validate_column_name(self, name)
+            _validate_column_name(
+                name=name,
+                config_events=self.config_events,
+                config_country_holidays=self.config_country_holidays,
+                config_seasonality=self.config_seasonality,
+                config_lagged_regressors=self.config_lagged_regressors,
+                config_regressors=self.config_regressors,
+            )
             if self.config_lagged_regressors is None:
                 self.config_lagged_regressors = OrderedDict()
             self.config_lagged_regressors[name] = configure.LaggedRegressor(
@@ -605,7 +612,14 @@ class NeuralProphet:
                 raise ValueError("regularization must be >= 0")
             if regularization == 0:
                 regularization = None
-        _validate_column_name(self, name)
+        _validate_column_name(
+            name=name,
+            config_events=self.config_events,
+            config_country_holidays=self.config_country_holidays,
+            config_seasonality=self.config_seasonality,
+            config_lagged_regressors=self.config_lagged_regressors,
+            config_regressors=self.config_regressors,
+        )
 
         if self.config_regressors is None:
             self.config_regressors = OrderedDict()
@@ -654,7 +668,14 @@ class NeuralProphet:
             events = [events]
 
         for event_name in events:
-            _validate_column_name(self, event_name)
+            _validate_column_name(
+                name=event_name,
+                config_events=self.config_events,
+                config_country_holidays=self.config_country_holidays,
+                config_seasonality=self.config_seasonality,
+                config_lagged_regressors=self.config_lagged_regressors,
+                config_regressors=self.config_regressors,
+            )
             self.config_events[event_name] = configure.Event(
                 lower_window=lower_window, upper_window=upper_window, reg_lambda=regularization, mode=mode
             )
@@ -761,9 +782,24 @@ class NeuralProphet:
         if name in ["daily", "weekly", "yearly"]:
             log.error("Please use inbuilt daily, weekly, or yearly seasonality or set another name.")
         # Do not Allow overwriting built-in seasonalities
-        _validate_column_name(self, name, seasons=True)
+        _validate_column_name(
+            name=name,
+            config_events=self.config_events,
+            config_country_holidays=self.config_country_holidays,
+            config_seasonality=self.config_seasonality,
+            config_lagged_regressors=self.config_lagged_regressors,
+            config_regressors=self.config_regressors,
+            seasons=True,
+        )
         if condition_name is not None:
-            _validate_column_name(self, condition_name)
+            _validate_column_name(
+                name=condition_name,
+                config_events=self.config_events,
+                config_country_holidays=self.config_country_holidays,
+                config_seasonality=self.config_seasonality,
+                config_lagged_regressors=self.config_lagged_regressors,
+                config_regressors=self.config_regressors,
+            )
         if fourier_order <= 0:
             raise ValueError("Fourier Order must be > 0")
         self.config_seasonality.append(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,7 +35,14 @@ PLOT = False
 def test_names():
     log.info("testing: names")
     m = NeuralProphet()
-    _validate_column_name(m, "hello_friend")
+    _validate_column_name(
+        name="hello_friend",
+        config_events=m.config_events,
+        config_country_holidays=m.config_country_holidays,
+        config_seasonality=m.config_seasonality,
+        config_lagged_regressors=m.config_lagged_regressors,
+        config_regressors=m.config_regressors,
+    )
 
 
 def test_train_eval_test():


### PR DESCRIPTION
## :microscope: Background

Related to #1133
This PR is part of a series of PRs belonging to **step 2 of restructuring the `forecaster.py`**. Step 1 was to move identified functions out of the forecaster.py into dedicated files. Step 2 is to encapsulate the input arguments of the moved functions. Step2 will be implemented step-by-step within multiple PRs

## :crystal_ball: Key changes

- Encapsulate `_validate_column_name` including docstring and typing

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- N.A. [ ] I have commented my code, added docstrings and data types to function definitions.
- N.A. [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).