### PR TITLE
[refactor] Encapsulate _prepare_dataframe_to_predict

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -997,7 +997,7 @@ class NeuralProphet:
             config_regressors=self.config_regressors,
             config_events=self.config_events,
         )
-        df = _prepare_dataframe_to_predict(self, df)
+        df = _prepare_dataframe_to_predict(model=self, df=df, max_lags=self.max_lags, freq=self.data_freq)
         # normalize
         df = _normalize(self, df)
         forecast = pd.DataFrame()


### PR DESCRIPTION
## :microscope: Background

Related to #1133
This PR is part of a series of PRs belonging to **step 2 of restructuring the `forecaster.py`**. Step 1 was to move identified functions out of the forecaster.py into dedicated files. Step 2 is to encapsulate the input arguments of the moved functions. Step2 will be implemented step-by-step within multiple PRs

## :crystal_ball: Key changes

- Encapsulate `_prepare_dataframe_to_predict` including docstring and typing. Model still needs to for passing on to `_check_dataframe`

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- N.A. [ ] I have commented my code, added docstrings and data types to function definitions.
- N.A. [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).