### PR TITLE
[refactor] Encapsulate _convert_raw_predictions_to_raw_df

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -146,7 +146,11 @@ def _reshape_raw_predictions_to_forecst_df(model, df, predicted, components, pre
 
 
 def _convert_raw_predictions_to_raw_df(
-    dates: pd.Series, predicted: np.ndarray, n_forecasts: int, quantiles: list, components: Optional[Components] = None
+    dates: pd.Series,
+    predicted: np.ndarray,
+    n_forecasts: int,
+    quantiles: List[float],
+    components: Optional[Components] = None,
 ) -> pd.DataFrame:
     """Turns forecast-origin-wise predictions into forecast-target-wise predictions.
 

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 
 from neuralprophet import df_utils, time_dataset
+from neuralprophet.np_types import Components
 
 log = logging.getLogger("NP.data.processing")
 
@@ -137,7 +138,9 @@ def _reshape_raw_predictions_to_forecst_df(model, df, predicted, components, pre
     return df_forecast
 
 
-def _convert_raw_predictions_to_raw_df(model, dates, predicted, components=None):
+def _convert_raw_predictions_to_raw_df(
+    dates: pd.Series, predicted: np.ndarray, n_forecasts: int, quantiles: list, components: Optional[Components] = None
+) -> pd.DataFrame:
     """Turns forecast-origin-wise predictions into forecast-target-wise predictions.
 
     Parameters
@@ -146,6 +149,10 @@ def _convert_raw_predictions_to_raw_df(model, dates, predicted, components=None)
             timestamps referring to the start of the predictions.
         predicted : np.array
             Array containing the forecasts
+        n_forecasts : int
+            optional, number of steps ahead of prediction time step to forecast
+        quantiles : list[float]
+            optional, list of quantiles for quantile regression uncertainty estimate
         components : dict[np.array]
             Dictionary of components containing an array of each components' contribution to the forecast
 
@@ -166,13 +173,13 @@ def _convert_raw_predictions_to_raw_df(model, dates, predicted, components=None)
     df_raw = pd.DataFrame()
     df_raw.insert(0, "ds", dates.values)
     df_raw.insert(1, "ID", "__df__")  # type: ignore
-    for forecast_lag in range(model.n_forecasts):
-        for quantile_idx in range(len(model.config_train.quantiles)):
+    for forecast_lag in range(n_forecasts):
+        for quantile_idx in range(len(quantiles)):
             # 0 is the median quantile index
             if quantile_idx == 0:
                 step_name = f"step{forecast_lag}"
             else:
-                step_name = f"step{forecast_lag} {model.config_train.quantiles[quantile_idx] * 100}%"
+                step_name = f"step{forecast_lag} {quantiles[quantile_idx] * 100}%"
             data = all_data[:, forecast_lag, quantile_idx]
             ser = pd.Series(data=data, name=step_name)
             df_raw = df_raw.merge(ser, left_index=True, right_index=True)

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 
 from neuralprophet import df_utils, time_dataset
-from neuralprophet.np_types import Components
 from neuralprophet.configure import (
     ConfigCountryHolidays,
     ConfigEvents,
@@ -13,6 +12,7 @@ from neuralprophet.configure import (
     ConfigLaggedRegressors,
     ConfigSeasonality,
 )
+from neuralprophet.np_types import Components
 
 log = logging.getLogger("NP.data.processing")
 

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1009,7 +1009,13 @@ class NeuralProphet:
                 df_i, self.config_missing.drop_missing, self.predict_steps, self.n_lags
             )
             if raw:
-                fcst = _convert_raw_predictions_to_raw_df(self, dates, predicted, components)
+                fcst = _convert_raw_predictions_to_raw_df(
+                    dates=dates,
+                    predicted=predicted,
+                    n_forecasts=self.n_forecasts,
+                    quantiles=self.config_train.quantiles,
+                    components=components,
+                )
                 if periods_added[df_name] > 0:
                     fcst = fcst[:-1]
             else:

--- a/neuralprophet/np_types.py
+++ b/neuralprophet/np_types.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Dict, List, Union
 
+import torch
 import torchmetrics
 
 # Ensure compatibility with python 3.7
@@ -21,3 +22,5 @@ GrowthMode = Literal["off", "linear", "discontinuous"]
 CollectMetricsMode = Union[List[str], bool, Dict[str, torchmetrics.Metric]]
 
 SeasonGlobalLocalMode = Literal["global", "local"]
+
+Components = Dict[str, torch.Tensor]


### PR DESCRIPTION
## :microscope: Background

Related to #1133
This PR is part of a series of PRs belonging to **step 2 of restructuring the `forecaster.py`**. Step 1 was to move identified functions out of the forecaster.py into dedicated files. Step 2 is to encapsulate the input arguments of the moved functions. Step2 will be implemented step-by-step within multiple PRs

## :crystal_ball: Key changes

- Encapsulate `_convert_raw_predictions_to_raw_df` including docstring and typing.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- N.A. [ ] I have commented my code, added docstrings and data types to function definitions.
- N.A. [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).