### PR TITLE
[minor] add docstring examples

### DIFF
--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -649,6 +649,10 @@ def set_random_seed(seed: int = 0):
     ----
     This needs to be set each time before fitting the model.
 
+    Example
+    -------
+    >>> from neuralprophet import set_random_seed
+    >>> set_random_seed(seed=42)
     """
     np.random.seed(seed)
     torch.manual_seed(seed)
@@ -682,6 +686,11 @@ def set_log_level(log_level: str = "INFO", include_handlers: bool = False):
             ``ERROR`` or ``CRITICAL``
         include_handlers : bool
             Include any specified file/stream handlers
+
+    Example
+    -------
+    >>> from neuralprophet import set_log_level
+    >>> set_log_level("ERROR")
     """
     set_logger_level(logging.getLogger("NP"), log_level, include_handlers)
 


### PR DESCRIPTION
## :microscope: Background

- We would like to add docstring examples for functions that are unclear to call individually to users.

## :crystal_ball: Key changes

- add example for `set_random_seed()`
- add example for `set_log_level()`

## :clipboard: Review Checklist
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, added docstrings and data types to function definitions.
- N.a. [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
