### PR TITLE
[fix] Raise ValueError when df contains not enough rows

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -397,6 +397,11 @@ def _check_dataframe(
         pd.DataFrame
             checked dataframe
     """
+    if len(df) < (model.n_forecasts + model.n_lags):
+        raise ValueError(
+            "Dataframe has less than n_forecasts + n_lags rows. "
+            "Forecasting not possible. Please either use a larger dataset, or adjust the model parameters."
+        )
     df, _, _, _ = df_utils.prep_or_copy_df(df)
     df, regressors_to_remove, lag_regressors_to_remove = df_utils.check_dataframe(
         df=df,

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -397,7 +397,7 @@ def _check_dataframe(
         pd.DataFrame
             checked dataframe
     """
-    if len(df) < (model.n_forecasts + model.n_lags):
+    if len(df) < (model.n_forecasts + model.n_lags) and not future:
         raise ValueError(
             "Dataframe has less than n_forecasts + n_lags rows. "
             "Forecasting not possible. Please either use a larger dataset, or adjust the model parameters."

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1355,6 +1355,12 @@ def test_get_latest_forecast():
     with pytest.raises(Exception):
         m.get_latest_forecast(forecast, include_previous_forecasts=10)
 
+    log.info("Not enough values in df")
+    df3 = df.iloc[:10].copy(deep=True)
+    df3["ID"] = "df3"
+    with pytest.raises(Exception):
+        metrics_df = m.fit(df3, freq="D")
+
 
 def test_metrics():
     log.info("testing: Plotting")


### PR DESCRIPTION
## :microscope: Background

- Fixes #1294 
- Closes #1257 

When using auto-regression with a dataset that is smaller than `n_forecasts` + `n_lags` the fit method throws an IndexError. This hides the real problem, which is that the user is trying to train a model on not enough data. 

## :crystal_ball: Key changes

- raise an error which tells the user to lower the number of forecasts and/or lags, or asks for a larger dataset

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.