### PR TITLE
[minor] Added default values to layers

### DIFF
--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -21,7 +21,13 @@ log = logging.getLogger("NP.config")
 
 @dataclass
 class Model:
+    n_lags: int
     lagged_reg_layers: Optional[List[int]]
+    n_forecasts: int = 1
+
+    def __post_init__(self):
+        if self.lagged_reg_layers is None and self.n_lags > 1:
+            self.lagged_reg_layers = [max(32, (self.n_lags + self.n_forecasts) // 4)]
 
 
 @dataclass
@@ -343,6 +349,7 @@ class ConfigSeasonality:
 @dataclass
 class AR:
     n_lags: int
+    n_forecasts: int = 1
     ar_reg: Optional[float] = None
     ar_layers: Optional[List[int]] = None
 
@@ -353,6 +360,9 @@ class AR:
             self.reg_lambda = 0.0001 * self.ar_reg
         else:
             self.reg_lambda = None
+
+        if self.ar_layers is None and self.n_lags > 1:
+            self.ar_layers = [max(32, (self.n_lags + self.n_forecasts) // 4)]
 
     def regularize(self, weights, original=False):
         """Regularization of AR coefficients

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -170,7 +170,7 @@ class NeuralProphet:
             default: 0 no regularization of coefficients.
         ar_layers : list of int, optional
             array of hidden layer dimensions of the AR-Net. Specifies number of hidden layers (number of entries)
-            and layer dimension (list entry).
+            and layer dimension (list entry). If auto-regression is used and no ar_layers are specified, default is set to [max(32, (self.n_lags + self.n_forecasts) // 4)].
 
         COMMENT
         Model Config
@@ -179,7 +179,7 @@ class NeuralProphet:
             Number of steps ahead of prediction time step to forecast.
         lagged_reg_layers : list of int, optional
             array of hidden layer dimensions of the Covar-Net. Specifies number of hidden layers (number of entries)
-            and layer dimension (list entry).
+            and layer dimension (list entry). If auto-regression is used and no lagged_reg_layers are specified, default is set to [max(32, (self.n_lags + self.n_forecasts) // 4)].
 
         COMMENT
         Train Config
@@ -416,12 +416,12 @@ class NeuralProphet:
         self.metrics = utils_metrics.get_metrics(collect_metrics)
 
         # AR
-        self.config_ar = configure.AR(n_lags=n_lags, ar_reg=ar_reg, ar_layers=ar_layers)
+        self.config_ar = configure.AR(n_lags=n_lags, n_forecasts=n_forecasts, ar_reg=ar_reg, ar_layers=ar_layers)
         self.n_lags = self.config_ar.n_lags
         self.max_lags = self.n_lags
 
         # Model
-        self.config_model = configure.Model(lagged_reg_layers=lagged_reg_layers)
+        self.config_model = configure.Model(n_lags=n_lags, lagged_reg_layers=lagged_reg_layers, n_forecasts=n_forecasts)
 
         # Trend
         self.config_trend = configure.Trend(


### PR DESCRIPTION
## :microscope: Background
Handle parameter explosion in AR-Net

## :crystal_ball: Key changes
added one default hidden layer to `ar_layers` and `lagged_reg_layers` if none and `n_lags>1`
default value is `max(32, (self.n_lags + self.n_forecasts) // 4)`

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.