### PR TITLE
[devops] Remove macos and windows from Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.10"]
     env:
       POETRY_VIRTUALENVS_CREATE: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.10"]
     env:
       POETRY_VIRTUALENVS_CREATE: false


### PR DESCRIPTION
## :microscope: Background

- There has not been any difference between the operating systems so far

## :crystal_ball: Key changes

- Remove macos and windows, as linux runs fastest
- Fixed #991 