### PR TITLE
Remove type conversion for _stride_lagged_features and _stride_future…

### DIFF
--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -314,20 +314,12 @@ def tabularize_univariate_datetime(
     inputs = OrderedDict({})
 
     def _stride_time_features_for_forecasts(x):
-        # only for case where n_lags > 0
-        if x.dtype != np.float64:
-            dtype = np.datetime64
-        else:
-            dtype = np.float64
-        return np.array([x[i + max_lags - n_lags : i + max_lags + n_forecasts] for i in range(n_samples)], dtype=dtype)
+        return np.array(
+            [x[i + max_lags - n_lags : i + max_lags + n_forecasts] for i in range(n_samples)], dtype=x.dtype
+        )
 
     def _stride_future_time_features_for_forecasts(x):
-        # only for case where n_lags > 0
-        if x.dtype != np.float64:
-            dtype = np.datetime64
-        else:
-            dtype = np.float64
-        return np.array([x[max_lags + i : max_lags + i + n_forecasts] for i in range(n_samples)], dtype=dtype)
+        return np.array([x[max_lags + i : max_lags + i + n_forecasts] for i in range(n_samples)], dtype=x.dtype)
 
     def _stride_lagged_features(df_col_name, feature_dims):
         # only for case where max_lags > 0


### PR DESCRIPTION
…_time_features_for_forecasts

## :microscope: Background

This fixes #1317. 

## :crystal_ball: Key changes

I removed the datetime conversions for  `_stride_time_features_for_forecasts` and `_stride_future_time_features_for_forecasts`.

## :clipboard: Review Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
