### PR TITLE
(Fix) pytorch_lightning<2.0.0 callbacks has ProgressBarBase class not…

### DIFF
--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -873,7 +873,7 @@ def configure_trainer(
     has_progressbar_callback = (
         True
         if has_custom_callbacks
-        and any(isinstance(callback, pl.callbacks.ProgressBar) for callback in config["callbacks"])
+        and any(isinstance(callback, pl.callbacks.ProgressBarBase) for callback in config["callbacks"])
         else False
     )
     if has_progressbar_callback and not progress_bar_enabled:


### PR DESCRIPTION
… ProgressBar

## :microscope: Background

- Why is this change needed? Is there a related issue or a new feature to be added?
- Fixed class name - changed ProgressBar class name to ProgressBarBase as former doesn't exist in pytorch-lightning <2.0.0

## :crystal_ball: Key changes

- Explain the main changes introduced by this pull request for the reviewer.

## :clipboard: Review Checklist
- [Y ] I have performed a self-review of my own code.
- [NA ] I have commented my code, added docstrings and data types to function definitions.
- [ N] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
