### PR TITLE
[major] Speed up split_df by vectorizing for loops

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -493,7 +493,6 @@ def _handle_missing_data(
             config_seasonality=config_seasonality,
             predicting=predicting,
         ).copy(deep=True)
-        df_handled_missing_aux["ID"] = df_name
         df_handled_missing = pd.concat((df_handled_missing, df_handled_missing_aux), ignore_index=True)
     return df_handled_missing
 

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -803,52 +803,6 @@ def double_crossvalidation_split_df(df, n_lags, n_forecasts, k, valid_pct, test_
     return folds_val, folds_test
 
 
-def _split_df(df, n_lags, n_forecasts, valid_p, inputs_overbleed):
-    """Splits timeseries df into train and validation sets.
-    Additionally, prevents overbleed of targets. Overbleed of inputs can be configured.
-    In case of global modeling the split could be either local or global.
-
-    Parameters
-    ----------
-        df : pd.DataFrame
-            data to be splitted
-        n_lags : int
-            identical to NeuralProphet
-        n_forecasts : int
-            identical to NeuralProphet
-        valid_p : float, int
-            fraction (0,1) of data to use for holdout validation set, or number of validation samples >1
-        inputs_overbleed : bool
-            Whether to allow last training targets to be first validation inputs (never targets)
-
-    Returns
-    -------
-        pd.DataFrame
-            training data
-        pd.DataFrame
-            validation data
-    """
-    # Receives df with single ID column
-    assert len(df["ID"].unique()) == 1
-    n_samples = len(df) - n_lags + 2 - (2 * n_forecasts)
-    n_samples = n_samples if inputs_overbleed else n_samples - n_lags
-    if 0.0 < valid_p < 1.0:
-        n_valid = max(1, int(n_samples * valid_p))
-    else:
-        assert valid_p >= 1
-        assert type(valid_p) == int
-        n_valid = valid_p
-    n_train = n_samples - n_valid
-    assert n_train >= 1
-
-    split_idx_train = n_train + n_lags + n_forecasts - 1
-    split_idx_val = split_idx_train - n_lags if inputs_overbleed else split_idx_train
-    df_train = df.copy(deep=True).iloc[:split_idx_train].reset_index(drop=True)
-    df_val = df.copy(deep=True).iloc[split_idx_val:].reset_index(drop=True)
-    log.debug(f"{n_train} n_train, {n_samples - n_train} n_eval")
-    return df_train, df_val
-
-
 def find_time_threshold(df, n_lags, n_forecasts, valid_p, inputs_overbleed):
     """Find time threshold for dividing timeseries into train and validation sets.
     Prevents overbleed of targets. Overbleed of inputs can be configured.

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -417,102 +417,6 @@ def normalize(df, data_params):
     return df
 
 
-def check_single_dataframe(df, check_y, covariates, regressors, events, seasonalities):
-    """Performs basic data sanity checks and ordering
-    as well as prepare dataframe for fitting or predicting.
-
-    Parameters
-    ----------
-        df : pd.DataFrame
-            with columns ds
-        check_y : bool
-            if df must have series values (``True`` if training or predicting with autoregression)
-        covariates : list or dict
-            covariate column names
-        regressors : list or dict
-            regressor column names
-        events : list or dict
-            event column names
-        seasonalities : list or dict
-            seasonalities column names
-
-    Returns
-    -------
-        pd.DataFrame
-    """
-    # Receives df with single ID column
-    assert len(df["ID"].unique()) == 1
-    if df.shape[0] == 0:
-        raise ValueError("Dataframe has no rows.")
-    if "ds" not in df:
-        raise ValueError('Dataframe must have columns "ds" with the dates.')
-    if df.loc[:, "ds"].isnull().any():
-        raise ValueError("Found NaN in column ds.")
-    if df["ds"].dtype == np.int64:
-        df["ds"] = df.loc[:, "ds"].astype(str)
-    if not np.issubdtype(df["ds"].dtype, np.datetime64):
-        df["ds"] = pd.to_datetime(df.loc[:, "ds"], utc=True).dt.tz_convert(None)
-    if len(df.ds.unique()) != len(df.ds):
-        raise ValueError("Column ds has duplicate values. Please remove duplicates.")
-    if regressors is not None:
-        for reg in regressors:
-            if len(df[reg].unique()) < 2:
-                log.warning(
-                    "Encountered future regressor with only unique values in training set. "
-                    "Variable will be removed for global modeling if this is true for all time series."
-                )
-    if covariates is not None:
-        for covar in covariates:
-            if len(df[covar].unique()) < 2:
-                log.warning(
-                    "Encountered lagged regressor with only unique values in training set. "
-                    "Variable will be removed for global modeling if this is true for all time series."
-                )
-
-    columns = []
-    if check_y:
-        columns.append("y")
-    if covariates is not None:
-        if type(covariates) is list:
-            columns.extend(covariates)
-        else:  # treat as dict
-            columns.extend(covariates.keys())
-    if regressors is not None:
-        if type(regressors) is list:
-            columns.extend(regressors)
-        else:  # treat as dict
-            columns.extend(regressors.keys())
-    if events is not None:
-        if type(events) is list:
-            columns.extend(events)
-        else:  # treat as dict
-            columns.extend(events.keys())
-    if seasonalities is not None:
-        for season in seasonalities.periods:
-            condition_name = seasonalities.periods[season].condition_name
-            if condition_name is not None:
-                if not df[condition_name].isin([True, False]).all() and not df[condition_name].between(0, 1).all():
-                    raise ValueError(f"Condition column {condition_name} must be boolean or numeric between 0 and 1.")
-                columns.append(condition_name)
-    for name in columns:
-        if name not in df:
-            raise ValueError(f"Column {name!r} missing from dataframe")
-        if df.loc[df.loc[:, name].notnull()].shape[0] < 1:
-            raise ValueError(f"Dataframe column {name!r} only has NaN rows.")
-        if not np.issubdtype(df[name].dtype, np.number):
-            df.loc[:, name] = pd.to_numeric(df.loc[:, name])
-        if np.isinf(df.loc[:, name].values).any():
-            df.loc[:, name] = df[name].replace([np.inf, -np.inf], np.nan)
-        if df.loc[df.loc[:, name].notnull()].shape[0] < 1:
-            raise ValueError(f"Dataframe column {name!r} only has NaN rows.")
-
-    if df.index.name == "ds":
-        df.index.name = None
-    df = df.sort_values("ds")
-    df = df.reset_index(drop=True)
-    return df
-
-
 def check_dataframe(
     df: pd.DataFrame,
     check_y: bool = True,
@@ -549,14 +453,31 @@ def check_dataframe(
             checked dataframe
     """
     df, _, _, _ = prep_or_copy_df(df)
-    checked_df = pd.DataFrame()
-    for df_name, df_i in df.groupby("ID"):
-        df_aux = check_single_dataframe(df_i, check_y, covariates, regressors, events, seasonalities)
-        df_aux = df_aux.copy(deep=True)
-        df_aux["ID"] = df_name
-        checked_df = pd.concat((checked_df, df_aux), ignore_index=True)
+    # checked_df = pd.DataFrame()
+    # for df_name, df_i in df.groupby("ID"):
+    #    df_aux = check_single_dataframe(df_i, check_y, covariates, regressors, events, seasonalities)
+    #    df_aux = df_aux.copy(deep=True)
+    #    df_aux["ID"] = df_name
+    #    checked_df = pd.concat((checked_df, df_aux), ignore_index=True)
+
+    if df.groupby("ID").size().min() < 1:
+        raise ValueError("Dataframe has no rows.")
+    if "ds" not in df:
+        raise ValueError("Dataframe must have columns 'ds' with the dates.")
+    if df["ds"].isnull().any():
+        raise ValueError("Found NaN in column ds.")
+    if df["ds"].dtype == np.int64:
+        df["ds"] = df.loc[:, "ds"].astype(str)
+    if not np.issubdtype(df["ds"].dtype, np.datetime64):
+        df["ds"] = pd.to_datetime(df.loc[:, "ds"], utc=True).dt.tz_convert(None)
+    if df.groupby("ID").apply(lambda x: x.duplicated("ds").any()).any():
+        raise ValueError("Column ds has duplicate values. Please remove duplicates.")
+
     regressors_to_remove = []
     lag_regressors_to_remove = []
+    columns = []
+    if check_y:
+        columns.append("y")
     if regressors is not None:
         for reg in regressors:
             if len(df[reg].unique()) < 2:
@@ -565,6 +486,10 @@ def check_dataframe(
                     "Automatically removed variable."
                 )
                 regressors_to_remove.append(reg)
+        if type(regressors) is list:
+            columns.extend(regressors)
+        else:  # treat as dict
+            columns.extend(regressors.keys())
     if covariates is not None:
         for covar in covariates:
             if len(df[covar].unique()) < 2:
@@ -573,17 +498,45 @@ def check_dataframe(
                     "Automatically removed variable."
                 )
                 lag_regressors_to_remove.append(covar)
+        if type(covariates) is list:
+            columns.extend(covariates)
+        else:  # treat as dict
+            columns.extend(covariates.keys())
+    if events is not None:
+        if type(events) is list:
+            columns.extend(events)
+        else:  # treat as dict
+            columns.extend(events.keys())
+    if seasonalities is not None:
+        for season in seasonalities.periods:
+            condition_name = seasonalities.periods[season].condition_name
+            if condition_name is not None:
+                if not df[condition_name].isin([True, False]).all() and not df[condition_name].between(0, 1).all():
+                    raise ValueError(f"Condition column {condition_name} must be boolean or numeric between 0 and 1.")
+                columns.append(condition_name)
+    for name in columns:
+        if name not in df:
+            raise ValueError(f"Column {name!r} missing from dataframe")
+        if df.loc[df.loc[:, name].notnull()].shape[0] < 1:
+            raise ValueError(f"Dataframe column {name!r} only has NaN rows.")
+        if not np.issubdtype(df[name].dtype, np.number):
+            df.loc[:, name] = pd.to_numeric(df.loc[:, name])
+        if np.isinf(df.loc[:, name].values).any():
+            df.loc[:, name] = df[name].replace([np.inf, -np.inf], np.nan)
+        if df.loc[df.loc[:, name].notnull()].shape[0] < 1:
+            raise ValueError(f"Dataframe column {name!r} only has NaN rows.")
+
     if future:
-        return checked_df, regressors_to_remove, lag_regressors_to_remove
+        return df, regressors_to_remove, lag_regressors_to_remove
     if len(regressors_to_remove) > 0:
         regressors_to_remove = list(set(regressors_to_remove))
-        checked_df = checked_df.drop(regressors_to_remove, axis=1)
-        assert checked_df is not None
+        df = df.drop(regressors_to_remove, axis=1)
+        assert df is not None
     if len(lag_regressors_to_remove) > 0:
         lag_regressors_to_remove = list(set(lag_regressors_to_remove))
-        checked_df = checked_df.drop(lag_regressors_to_remove, axis=1)
-        assert checked_df is not None
-    return checked_df, regressors_to_remove, lag_regressors_to_remove
+        df = df.drop(lag_regressors_to_remove, axis=1)
+        assert df is not None
+    return df, regressors_to_remove, lag_regressors_to_remove
 
 
 def _crossvalidation_split_df(df, n_lags, n_forecasts, k, fold_pct, fold_overlap_pct=0.0):

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -453,13 +453,6 @@ def check_dataframe(
             checked dataframe
     """
     df, _, _, _ = prep_or_copy_df(df)
-    # checked_df = pd.DataFrame()
-    # for df_name, df_i in df.groupby("ID"):
-    #    df_aux = check_single_dataframe(df_i, check_y, covariates, regressors, events, seasonalities)
-    #    df_aux = df_aux.copy(deep=True)
-    #    df_aux["ID"] = df_name
-    #    checked_df = pd.concat((checked_df, df_aux), ignore_index=True)
-
     if df.groupby("ID").size().min() < 1:
         raise ValueError("Dataframe has no rows.")
     if "ds" not in df:
@@ -468,7 +461,7 @@ def check_dataframe(
         raise ValueError("Found NaN in column ds.")
     if df["ds"].dtype == np.int64:
         df["ds"] = df.loc[:, "ds"].astype(str)
-    if not np.issubdtype(df["ds"].dtype, np.datetime64):
+    if not np.issubdtype(df["ds"].to_numpy().dtype, np.datetime64):
         df["ds"] = pd.to_datetime(df.loc[:, "ds"], utc=True).dt.tz_convert(None)
     if df.groupby("ID").apply(lambda x: x.duplicated("ds").any()).any():
         raise ValueError("Column ds has duplicate values. Please remove duplicates.")

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -513,7 +513,7 @@ def check_dataframe(
         if df.loc[df.loc[:, name].notnull()].shape[0] < 1:
             raise ValueError(f"Dataframe column {name!r} only has NaN rows.")
         if not np.issubdtype(df[name].dtype, np.number):
-            df.loc[:, name] = pd.to_numeric(df.loc[:, name])
+            df[name] = pd.to_numeric(df[name])
         if np.isinf(df.loc[:, name].values).any():
             df.loc[:, name] = df[name].replace([np.inf, -np.inf], np.nan)
         if df.loc[df.loc[:, name].notnull()].shape[0] < 1:


### PR DESCRIPTION
## :microscope: Background
This part of a bigger change, where successively NP will be sped up.
Split_df gets very slow, the more IDs are added

## :crystal_ball: Key changes
The following sub functions are accelerated:

- [x] check_dataframe --> ~10x faster
- [x] handle_missing_data --> ~100x faster
- [x] split_df

## ⏩ Speed up in s


No. IDs | Before total | After Total | Before check_datafram | After check_dataframe | Before handle_missing_data | After handle_missing_data | Before split_df | After split_df
-- | -- | -- | -- | -- | -- | -- | -- | --
8 | 1.4 | 0.5 | 0.3 | 0.2 | 0.19 | 0.03 | 0.2 | 0.1
16 | 3.8 | 0.9 | 0.5 | 0.4 | 0.52 | 0.06 | 0.3 | 0.2
32 | 21.6 | 2.2 | 1.3 | 0.7 | 0.91 | 0.11 | 0.8 | 0.5
64 | 48.5 | 5.2 | 4.4 | 1.8 | 5.4 | 0.42 | 3.7 | 1.5
128 | 131.9 | 9 | 12 | 3.4 | 18 | 0.85 | 12 | 4.4
256 | 570.9 | 16 | 35 | 6.7 | 55 | 1.33 | 37 | 4.5
512 | 1504.1 | 35 | 161 | 14 | 151 | 1.18 | 97 | 6.4






