### PR TITLE
[minor] Memory efficient float32 types instead of float64 types

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -132,7 +132,7 @@ def _reshape_raw_predictions_to_forecst_df(
             for j in range(len(quantiles)):
                 forecast_0 = components[comp][0, :, j]
                 forecast_rest = components[comp][1:, n_forecasts - 1, j]
-                yhat = yhat = np.pad(
+                yhat = np.pad(
                     np.concatenate((forecast_0, forecast_rest)), (max_lags, 0), mode="constant", constant_values=np.NaN
                 )
                 if prediction_frequency is not None:

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -572,7 +572,7 @@ def _handle_missing_data(
     return df
 
 
-def _create_dataset(model, df, predict_mode, prediction_frequency=None):
+def _create_dataset(model, df, predict_mode, prediction_frequency=None, num_workers=0):
     """Construct dataset from dataframe.
 
     (Configured Hyperparameters can be overridden by explicitly supplying them.
@@ -605,6 +605,9 @@ def _create_dataset(model, df, predict_mode, prediction_frequency=None):
             value: int
                 forecast origin of the predictions to be made, e.g. 7 for 7am in case of 'daily-hour'.
 
+        num_workers : int
+            number of workers to use for data loading
+
     Returns
     -------
         TimeDataset
@@ -612,6 +615,7 @@ def _create_dataset(model, df, predict_mode, prediction_frequency=None):
     df, _, _, _ = df_utils.prep_or_copy_df(df)
     return time_dataset.GlobalTimeDataset(
         df,
+        num_workers=num_workers,
         predict_mode=predict_mode,
         n_lags=model.n_lags,
         n_forecasts=model.n_forecasts,

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -572,7 +572,7 @@ def _handle_missing_data(
     return df
 
 
-def _create_dataset(model, df, predict_mode, prediction_frequency=None, num_workers=0):
+def _create_dataset(model, df, predict_mode, prediction_frequency=None):
     """Construct dataset from dataframe.
 
     (Configured Hyperparameters can be overridden by explicitly supplying them.
@@ -605,9 +605,6 @@ def _create_dataset(model, df, predict_mode, prediction_frequency=None, num_work
             value: int
                 forecast origin of the predictions to be made, e.g. 7 for 7am in case of 'daily-hour'.
 
-        num_workers : int
-            number of workers to use for data loading
-
     Returns
     -------
         TimeDataset
@@ -615,7 +612,6 @@ def _create_dataset(model, df, predict_mode, prediction_frequency=None, num_work
     df, _, _, _ = df_utils.prep_or_copy_df(df)
     return time_dataset.GlobalTimeDataset(
         df,
-        num_workers=num_workers,
         predict_mode=predict_mode,
         n_lags=model.n_lags,
         n_forecasts=model.n_forecasts,

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -517,6 +517,8 @@ def _handle_missing_data(
             df_to_add = df.groupby("ID", group_keys=False).apply(lambda x: x.loc[last_valid_index[x.name] + 1 :])
             df = df_dropped
             log.info(f"Dropped {n_dropped} rows at the end with NaNs in 'y' column.")
+    if df["y"].dtype != np.float32:
+        df["y"] = df["y"].astype(np.float32)
 
     if config_missing.impute_missing:
         # impute missing values

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -76,7 +76,7 @@ def _reshape_raw_predictions_to_forecst_df(
             forecast = predicted[:, forecast_lag - 1, j]
             pad_before = max_lags + forecast_lag - 1
             pad_after = n_forecasts - forecast_lag
-            yhat = np.concatenate(([np.NaN] * pad_before, forecast, [np.NaN] * pad_after))
+            yhat = np.pad(forecast, (pad_before, pad_after), mode="constant", constant_values=np.NaN)
             if prediction_frequency is not None:
                 ds = df_forecast["ds"].iloc[pad_before : -pad_after if pad_after > 0 else None]
                 mask = df_utils.create_mask_for_prediction_frequency(
@@ -86,7 +86,7 @@ def _reshape_raw_predictions_to_forecst_df(
                 )
                 yhat = np.full((len(ds),), np.nan)
                 yhat[mask] = forecast
-                yhat = np.concatenate(([np.NaN] * pad_before, yhat, [np.NaN] * pad_after))
+                yhat = np.pad(yhat, (pad_before, pad_after), mode="constant", constant_values=np.NaN)
             # 0 is the median quantile index
             if j == 0:
                 name = f"yhat{forecast_lag}"
@@ -111,7 +111,7 @@ def _reshape_raw_predictions_to_forecst_df(
                     forecast = components[comp][:, forecast_lag - 1, j]  # 0 is the median quantile
                     pad_before = max_lags + forecast_lag - 1
                     pad_after = n_forecasts - forecast_lag
-                    yhat = np.concatenate(([np.NaN] * pad_before, forecast, [np.NaN] * pad_after))
+                    yhat = np.pad(forecast, (pad_before, pad_after), mode="constant", constant_values=np.NaN)
                     if prediction_frequency is not None:
                         ds = df_forecast["ds"].iloc[pad_before : -pad_after if pad_after > 0 else None]
                         mask = df_utils.create_mask_for_prediction_frequency(
@@ -121,7 +121,7 @@ def _reshape_raw_predictions_to_forecst_df(
                         )
                         yhat = np.full((len(ds),), np.nan)
                         yhat[mask] = forecast
-                        yhat = np.concatenate(([np.NaN] * pad_before, yhat, [np.NaN] * pad_after))
+                        yhat = np.pad(yhat, (pad_before, pad_after), mode="constant", constant_values=np.NaN)
                     if j == 0:  # temporary condition to add only the median component
                         name = f"{comp}{forecast_lag}"
                         df_forecast[name] = yhat
@@ -132,7 +132,9 @@ def _reshape_raw_predictions_to_forecst_df(
             for j in range(len(quantiles)):
                 forecast_0 = components[comp][0, :, j]
                 forecast_rest = components[comp][1:, n_forecasts - 1, j]
-                yhat = np.concatenate(([np.NaN] * max_lags, forecast_0, forecast_rest))
+                yhat = yhat = np.pad(
+                    np.concatenate((forecast_0, forecast_rest)), (max_lags, 0), mode="constant", constant_values=np.NaN
+                )
                 if prediction_frequency is not None:
                     date_list = []
                     for key, value in prediction_frequency.items():

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -519,8 +519,6 @@ def _handle_missing_data(
             df_to_add = df.groupby("ID", group_keys=False).apply(lambda x: x.loc[last_valid_index[x.name] + 1 :])
             df = df_dropped
             log.info(f"Dropped {n_dropped} rows at the end with NaNs in 'y' column.")
-    if df["y"].dtype != np.float32:
-        df["y"] = df["y"].astype(np.float32)
 
     if config_missing.impute_missing:
         # impute missing values

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -459,8 +459,6 @@ def check_dataframe(
         raise ValueError("Dataframe must have columns 'ds' with the dates.")
     if df["ds"].isnull().any():
         raise ValueError("Found NaN in column ds.")
-    if df["ds"].dtype == np.int64:
-        df["ds"] = df.loc[:, "ds"].astype(str)
     if not np.issubdtype(df["ds"].to_numpy().dtype, np.datetime64):
         df["ds"] = pd.to_datetime(df.loc[:, "ds"], utc=True).dt.tz_convert(None)
     if df.groupby("ID").apply(lambda x: x.duplicated("ds").any()).any():

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -463,8 +463,6 @@ def check_dataframe(
         df["ds"] = df.loc[:, "ds"].astype(str)
     if not np.issubdtype(df["ds"].to_numpy().dtype, np.datetime64):
         df["ds"] = pd.to_datetime(df.loc[:, "ds"], utc=True).dt.tz_convert(None)
-    if df["y"].dtype != np.float32:
-        df["y"] = df["y"].astype(np.float32)
     if df.groupby("ID").apply(lambda x: x.duplicated("ds").any()).any():
         raise ValueError("Column ds has duplicate values. Please remove duplicates.")
 

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -1020,7 +1020,7 @@ def convert_events_to_features(df, config_events: ConfigEvents, events_df):
     """
 
     for event in config_events.keys():
-        event_feature = pd.Series([0.0] * df.shape[0])
+        event_feature = pd.Series(0, index=range(df.shape[0]), dtype="float32")
         # events_df may be None in case ID from original df is not provided in events df
         if events_df is None:
             dates = None

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -463,6 +463,8 @@ def check_dataframe(
         df["ds"] = df.loc[:, "ds"].astype(str)
     if not np.issubdtype(df["ds"].to_numpy().dtype, np.datetime64):
         df["ds"] = pd.to_datetime(df.loc[:, "ds"], utc=True).dt.tz_convert(None)
+    if df["y"].dtype != np.float32:
+        df["y"] = df["y"].astype(np.float32)
     if df.groupby("ID").apply(lambda x: x.duplicated("ds").any()).any():
         raise ValueError("Column ds has duplicate values. Please remove duplicates.")
 

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2567,7 +2567,7 @@ class NeuralProphet:
             self.config_country_holidays.init_holidays(df_merged)
 
         dataset = _create_dataset(
-            self, df, predict_mode=False, prediction_frequency=self.prediction_frequency, num_workers=num_workers
+            self, df, predict_mode=False, prediction_frequency=self.prediction_frequency
         )  # needs to be called after set_auto_seasonalities
 
         # Determine the max_number of epochs
@@ -2577,6 +2577,7 @@ class NeuralProphet:
             dataset,
             batch_size=self.config_train.batch_size,
             shuffle=True,
+            num_workers=num_workers,
         )
 
         return loader

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2567,7 +2567,7 @@ class NeuralProphet:
             self.config_country_holidays.init_holidays(df_merged)
 
         dataset = _create_dataset(
-            self, df, predict_mode=False, prediction_frequency=self.prediction_frequency
+            self, df, predict_mode=False, prediction_frequency=self.prediction_frequency, num_workers=num_workers
         )  # needs to be called after set_auto_seasonalities
 
         # Determine the max_number of epochs
@@ -2577,7 +2577,6 @@ class NeuralProphet:
             dataset,
             batch_size=self.config_train.batch_size,
             shuffle=True,
-            num_workers=num_workers,
         )
 
         return loader

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -28,8 +28,8 @@ class GlobalTimeDataset(Dataset):
                 Identical to :meth:`tabularize_univariate_datetime`
         """
         # TODO (future): vectorize
+        log.info(f"num_workers: {num_workers}")
         if num_workers > 0:
-            log.info(f"num_workers: {num_workers}")
             grouped_dfs = list(df.groupby("ID"))
             df_names = [item[0] for item in grouped_dfs]
             dataframes = [item[1] for item in grouped_dfs]

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -6,6 +6,7 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 import torch
+from memory_profiler import profile
 from torch.utils.data.dataset import Dataset
 
 from neuralprophet import configure, utils
@@ -63,6 +64,7 @@ class TimeDataset(Dataset):
             "events",
             "regressors",
         ]
+        log.info(f"Creating dataset for {name}")
         inputs, targets, drop_missing = tabularize_univariate_datetime(df, **kwargs)
         self.init_after_tabularized(inputs, targets)
         self.filter_samples_after_init(kwargs["prediction_frequency"])
@@ -111,6 +113,7 @@ class TimeDataset(Dataset):
                 "Please either adjust imputation parameters, or set 'drop_missing' to True to drop those samples."
             )
 
+    @profile
     def init_after_tabularized(self, inputs, targets=None):
         """Create Timedataset with data.
         Parameters

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -29,7 +29,7 @@ class GlobalTimeDataset(Dataset):
         """
         # TODO (future): vectorize
         if num_workers > 0:
-            print(f"num_workers: {num_workers}")
+            log.info(f"num_workers: {num_workers}")
             grouped_dfs = list(df.groupby("ID"))
             df_names = [item[0] for item in grouped_dfs]
             dataframes = [item[1] for item in grouped_dfs]
@@ -43,7 +43,7 @@ class GlobalTimeDataset(Dataset):
     @staticmethod
     def worker_function(args):
         df_i, df_name, kwargs = args
-        print(f"Creating dataset for {df_name}")
+        log.info(f"Creating dataset for {df_name}")
         return TimeDataset(df_i, df_name, **kwargs)
 
     @staticmethod

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -7,7 +7,6 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 import torch
-from memory_profiler import profile
 from torch.utils.data.dataset import Dataset
 
 from neuralprophet import configure, utils

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -1,6 +1,7 @@
 import logging
 from collections import OrderedDict, defaultdict
 from datetime import datetime
+from multiprocessing import Pool
 from typing import Optional
 
 import numpy as np
@@ -17,7 +18,7 @@ log = logging.getLogger("NP.time_dataset")
 
 
 class GlobalTimeDataset(Dataset):
-    def __init__(self, df, **kwargs):
+    def __init__(self, df, num_workers, **kwargs):
         """Initialize Timedataset from time-series df.
         Parameters
         ----------
@@ -27,10 +28,33 @@ class GlobalTimeDataset(Dataset):
             **kwargs : dict
                 Identical to :meth:`tabularize_univariate_datetime`
         """
-        # # TODO (future): vectorize
-        timedatasets = [TimeDataset(df_i, df_name, **kwargs) for df_name, df_i in df.groupby("ID")]
+        # TODO (future): vectorize
+        if num_workers > 0:
+            print(f"num_workers: {num_workers}")
+            grouped_dfs = list(df.groupby("ID"))
+            df_names = [item[0] for item in grouped_dfs]
+            dataframes = [item[1] for item in grouped_dfs]
+            timedatasets = self.parallel_time_datasets(dataframes, df_names, kwargs, num_workers)
+        else:
+            timedatasets = [TimeDataset(df_i, df_name, **kwargs) for df_name, df_i in df.groupby("ID")]
+
         self.combined_timedataset = [item for timedataset in timedatasets for item in timedataset]
         self.length = sum(timedataset.length for timedataset in timedatasets)
+
+    @staticmethod
+    def worker_function(args):
+        df_i, df_name, kwargs = args
+        print(f"Creating dataset for {df_name}")
+        return TimeDataset(df_i, df_name, **kwargs)
+
+    @staticmethod
+    def parallel_time_datasets(dataframes, df_names, kwargs, num_workers):
+        args = [(df_i, df_name, kwargs) for df_i, df_name in zip(dataframes, df_names)]
+
+        with Pool(num_workers) as pool:
+            results = pool.map(GlobalTimeDataset.worker_function, args)
+
+        return results
 
     def __len__(self):
         return self.length
@@ -64,7 +88,6 @@ class TimeDataset(Dataset):
             "events",
             "regressors",
         ]
-        log.info(f"Creating dataset for {name}")
         inputs, targets, drop_missing = tabularize_univariate_datetime(df, **kwargs)
         self.init_after_tabularized(inputs, targets)
         self.filter_samples_after_init(kwargs["prediction_frequency"])
@@ -113,7 +136,6 @@ class TimeDataset(Dataset):
                 "Please either adjust imputation parameters, or set 'drop_missing' to True to drop those samples."
             )
 
-    @profile
     def init_after_tabularized(self, inputs, targets=None):
         """Create Timedataset with data.
         Parameters

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -142,7 +142,9 @@ class TimeDataset(Dataset):
                     tensor = torch.from_numpy(features)
 
                     if tensor.dtype != inputs_dtype[key]:
-                        self.inputs[key][name] = tensor.to(dtype=inputs_dtype[key])
+                        self.inputs[key][name] = tensor.to(
+                            dtype=inputs_dtype[key]
+                        )  # this can probably be removed, but was included in the previous code
                     else:
                         self.inputs[key][name] = tensor
             else:
@@ -610,8 +612,6 @@ def make_events_features(df, config_events: Optional[configure.ConfigEvents] = N
     # create all user specified events
     if config_events is not None:
         for event, configs in config_events.items():
-            if event not in df.columns:
-                df[event] = np.zeros_like(df["ds"], dtype=np.float32)
             feature = df[event]
             _create_event_offset_features(event, configs, feature, additive_events, multiplicative_events)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -962,3 +962,17 @@ def test_multiple_countries():
     assert "Christmas Day" not in holiday_names
     assert "Erster Weihnachtstag" in holiday_names
     assert "Neujahr" in holiday_names
+
+
+def test_float32_inputs():
+    # test if float32 inputs are forecasted as float32 outputs
+    df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
+    df["y"] = df["y"].astype(np.float32)
+    m = NeuralProphet(
+        epochs=EPOCHS,
+        batch_size=BATCH_SIZE,
+        learning_rate=LR,
+    )
+    m.fit(df, freq="D")
+    forecast = m.predict(df)
+    assert forecast["yhat1"].dtype == np.float32


### PR DESCRIPTION
## :microscope: Background
The whole computation was done with float64 types, but torch tensors are float32 anyway and most of the ML models use float32 values. This will affect model accuracy but I think its worth it because we safe a lot of memory!

## :crystal_ball: Key changes

- y and yhat values: float32 if float32 is inserted, float64 if float64 is inserted
- time values: will always be float64 because `np.datetime64`
- feature values (events): float32 