### PR TITLE
[minor] Add a verbose option to NeuralProphet.test

### DIFF
--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1101,13 +1101,15 @@ class NeuralProphet:
         self.predict_steps = self.n_forecasts
         return df
 
-    def test(self, df: pd.DataFrame):
+    def test(self, df: pd.DataFrame, verbose: bool = True):
         """Evaluate model on holdout data.
 
         Parameters
         ----------
             df : pd.DataFrame
                 dataframe containing column ``ds``, ``y``, and optionally``ID`` with with holdout data
+            verbose : bool
+                If True, prints the test results.
         Returns
         -------
             pd.DataFrame
@@ -1132,7 +1134,7 @@ class NeuralProphet:
         )
         loader = self._init_val_loader(df)
         # Use Lightning to calculate metrics
-        val_metrics = self.trainer.test(self.model, dataloaders=loader)
+        val_metrics = self.trainer.test(self.model, dataloaders=loader, verbose=verbose)
         val_metrics_df = pd.DataFrame(val_metrics)
         # TODO Check whether supported by Lightning
         if not self.config_normalization.global_normalization:


### PR DESCRIPTION
## :microscope: Background

resolves #1367 

## :crystal_ball: Key changes

Add a `verbose` arg to `NeuralProphet.test`, surfacing the verbose option on `trainer.test`

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
