### PR TITLE
[fix] Remove wrong plotting warning

### DIFF
--- a/neuralprophet/plot_utils.py
+++ b/neuralprophet/plot_utils.py
@@ -304,10 +304,6 @@ def get_valid_configuration(  # move to utils
                         )
                     else:
                         df_name = m.id_list[0]
-                        log.warning(
-                            "Local model set with > 1 time series in the pd.DataFrame. Plotting components of first \
-                                time series. "
-                        )
                 else:
                     log.warning("Local normalization set, but df_name is None. Using global data params instead.")
                     df_name = "__df__"


### PR DESCRIPTION
## :microscope: Background

- closes #1391 

## :crystal_ball: Key changes

- Removed the wrong warning in case of global model.

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
