### PR TITLE
Add the trainer back to the forecaster after saving model to file

### DIFF
--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -38,9 +38,16 @@ def save(forecaster, path: str):
         >>> save(forecaster, "test_save_model.np")
     """
     # Remove the Lightning trainer since it does not serialise correcly with torch.save
-    for attr in ["trainer"]:
+    attrs_to_remove = ["trainer"]
+    removed_attrs = {}
+    for attr in attrs_to_remove:
+        removed_attrs[attr] = getattr(forecaster, attr)
         setattr(forecaster, attr, None)
     torch.save(forecaster, path)
+
+    # Restore the Lightning trainer
+    for attr in attrs_to_remove:
+        setattr(forecaster, attr, removed_attrs[attr])
 
 
 def load(path: str):


### PR DESCRIPTION
## :microscope: Background

- Why is this change needed? Is there a related issue or a new feature to be added?

After `save`, `forecaster.predict` won't work as the trainer is removed. 

To reproduce:

```python 
import pandas as pd
from neuralprophet import NeuralProphet, set_log_level, df_utils
from neuralprophet import save as npsave

data_location = "https://raw.githubusercontent.com/ourownstory/neuralprophet-data/main/datasets/yosemite_temps.csv"
df = pd.read_csv(data_location)

# first model
m = NeuralProphet()
_ = m.fit(df, epochs=2, learning_rate=0.01, progress=None)
npsave(m, "test.np")
forecast = m.predict(df.iloc[-2:])
```
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[110], line 12
     10 _ = m.fit(df, epochs=2, learning_rate=0.01, progress=None)
     11 npsave(m, "test.np")
---> 12 forecast = m.predict(df.iloc[-2:])

File ~/mambaforge/envs/neuralprophet/lib/python3.8/site-packages/neuralprophet/forecaster.py:1049, in NeuralProphet.predict(self, df, decompose, raw)
   1047 forecast = pd.DataFrame()
   1048 for df_name, df_i in df.groupby("ID"):
-> 1049     dates, predicted, components = self._predict_raw(
   1050         df_i, df_name, include_components=decompose, prediction_frequency=self.prediction_frequency
   1051     )
   1052     df_i = df_utils.drop_missing_from_df(
   1053         df_i, self.config_missing.drop_missing, self.predict_steps, self.n_lags
   1054     )
   1055     if raw:

File ~/mambaforge/envs/neuralprophet/lib/python3.8/site-packages/neuralprophet/forecaster.py:2746, in NeuralProphet._predict_raw(self, df, df_name, include_components, prediction_frequency)
   2744     self.model.set_covar_weights(self.model.get_covar_weights())
   2745 # Compute the predictions and components (if requested)
-> 2746 result = self.trainer.predict(self.model, loader)
   2747 # Extract the prediction and components
   2748 predicted, component_vectors = zip(*result)

AttributeError: 'NoneType' object has no attribute 'predict'
```

## :crystal_ball: Key changes

- Explain the main changes introduced by this pull request for the reviewer.

Add the trainer back to the forecaster after `torch.save`

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
