### PR TITLE
[fix] Pytests Plots

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -724,7 +724,6 @@ def test_advanced_conformal_prediction_plots():
     train_df, cal_df = m.split_df(train_df, freq="D", valid_p=0.15)
     m.fit(train_df, freq="D")
     alpha = 0.1
-    plotting_backend = "plotly"
     for method in ["naive", "cqr"]:  # Naive and CQR SCP methods
         future = m.make_future_dataframe(test_df, periods=m.n_forecasts, n_historic_predictions=10)
         forecast = m.conformal_predict(

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -665,9 +665,7 @@ def test_plot_conformal_prediction(plotting_backend):
     alpha = 0.1
     for method in ["naive", "cqr"]:  # Naive and CQR SCP methods
         future = m.make_future_dataframe(test_df, periods=m.n_forecasts, n_historic_predictions=10)
-        forecast = m.conformal_predict(
-            future, calibration_df=cal_df, alpha=alpha, method=method, plotting_backend=plotting_backend
-        )
+        forecast = m.conformal_predict(future, calibration_df=cal_df, alpha=alpha, method=method)
         m.highlight_nth_step_ahead_of_each_forecast(m.n_forecasts)
         fig0 = m.plot(forecast, plotting_backend=plotting_backend)
         fig1 = m.plot_components(forecast, plotting_backend=plotting_backend)
@@ -691,9 +689,7 @@ def test_plot_conformal_prediction(plotting_backend):
     alpha = 0.1
     for method in ["naive", "cqr"]:  # Naive and CQR SCP methods
         future = m.make_future_dataframe(df, periods=m.n_forecasts, n_historic_predictions=10)
-        forecast = m.conformal_predict(
-            future, calibration_df=cal_df, alpha=alpha, method=method, plotting_backend=plotting_backend
-        )
+        forecast = m.conformal_predict(future, calibration_df=cal_df, alpha=alpha, method=method)
         m.highlight_nth_step_ahead_of_each_forecast(m.n_forecasts)
         fig0 = m.plot(forecast)
         fig1 = m.plot_latest_forecast(forecast, include_previous_forecasts=10, plotting_backend=plotting_backend)
@@ -736,7 +732,6 @@ def test_advanced_conformal_prediction_plots():
             calibration_df=cal_df,
             alpha=alpha,
             method=method,
-            plotting_backend=plotting_backend,
             show_all_PI=True,
         )
         fig0 = m.conformal_plot(forecast)
@@ -762,9 +757,7 @@ def test_plot_conformal_prediction_asymmetric(plotting_backend):
     alpha = (0.03, 0.07)
     method = "cqr"
     future = m.make_future_dataframe(test_df, periods=m.n_forecasts, n_historic_predictions=10)
-    forecast = m.conformal_predict(
-        future, calibration_df=cal_df, alpha=alpha, method=method, plotting_backend=plotting_backend
-    )
+    forecast = m.conformal_predict(future, calibration_df=cal_df, alpha=alpha, method=method)
     m.highlight_nth_step_ahead_of_each_forecast(m.n_forecasts)
     fig0 = m.plot(forecast, plotting_backend=plotting_backend)
     fig1 = m.plot_components(forecast, plotting_backend=plotting_backend)


### PR DESCRIPTION
## :microscope: Background

- During testing some plots opened.

## :crystal_ball: Key changes

- Built-in plotting in conformal_predict disabled when running pytests.

## :clipboard: Review Checklist
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, added docstrings and data types to function definitions.
- [X] I have added pytests to check whether my feature / fix works.
