### PR TITLE
Skip windows python 3.8 tests in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.10"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.8"
     env:
       POETRY_VIRTUALENVS_CREATE: false
     steps:


### PR DESCRIPTION
due to plotting backend unreliably installing in CI jobs.
