### PR TITLE
[Minor] SmoothL1Loss correctly mentioned instead of Huber

### DIFF
--- a/docs/source/how-to-guides/feature-guides/hyperparameter-selection.md
+++ b/docs/source/how-to-guides/feature-guides/hyperparameter-selection.md
@@ -27,7 +27,7 @@ If it looks like the model is overfitting to the training data (the live loss pl
 you can reduce `epochs`  and `learning_rate`, and potentially increase the `batch_size`. 
 If it is underfitting, the number of `epochs` and `learning_rate` can be increased and the `batch_size` potentially decreased. 
 
-The default loss function is the 'Huber' loss, which is considered to be robust to outliers. 
+The default loss function is the 'SmoothL1Loss' loss, which is considered to be robust to outliers. 
 However, you are free to choose the standard `MSE` or any other PyTorch `torch.nn.modules.loss` loss function. 
 
 ## Increasing Depth of the Model

--- a/docs/zh/超参数选取.md
+++ b/docs/zh/超参数选取.md
@@ -22,7 +22,7 @@ NeuralProphet有一些超参数需要用户指定。如果没有指定，将使�
 | `learning_rate`       | None          |
 | `epochs`              | None          |
 | `batch_size`          | None          |
-| `loss_func`           | Huber         |
+| `loss_func`           | SmoothL1Loss  |
 | `train_speed`         | None          |
 | `normalize_y`         | auto          |
 | `impute_missing`      | True          |
@@ -43,7 +43,7 @@ NeuralProphet采用随机梯度下降法进行拟合--更准确地说，是采�
 
 如果看起来模型对训练数据过度拟合（实时损失图在此很有用），可以减少 `epochs` 和 `learning_rate`，并有可能增加 `batch_size`。如果是低拟合，可以增加`epochs` 和`learning_rate` 的数量，并有可能减少`batch_size` 。
 
-默认的损失函数是 "Huber "损失，该函数被认为对离群值具有鲁棒性。但是，您可以自由选择标准的 "MSE "或任何其他PyTorch `torch.nn.modules.loss`损失函数。
+默认的损失函数是 "SmoothL1Loss "损失，该函数被认为对离群值具有鲁棒性。但是，您可以自由选择标准的 "MSE "或任何其他PyTorch `torch.nn.modules.loss`损失函数。
 
 ## 增加模型的深度
 

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -119,7 +119,7 @@ class Train:
         if isinstance(self.loss_func, str):
             if self.loss_func.lower() in ["smoothl1", "smoothl1loss", "huber"]:
                 # keeping 'huber' for backwards compatiblility, though not identical
-                self.loss_func = torch.nn.SmoothL1Loss(reduction="none", beta=0.3)
+                self.loss_func = torch.nn.SmoothL1Loss(reduction="none", beta=1.0)
             elif self.loss_func.lower() in ["mae", "maeloss", "l1", "l1loss"]:
                 self.loss_func = torch.nn.L1Loss(reduction="none")
             elif self.loss_func.lower() in ["mse", "mseloss", "l2", "l2loss"]:

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -117,9 +117,10 @@ class Train:
 
     def set_loss_func(self):
         if isinstance(self.loss_func, str):
-            if self.loss_func.lower() in ["huber", "smoothl1", "smoothl1loss"]:
-                self.loss_func = torch.nn.SmoothL1Loss(reduction="none")
-            elif self.loss_func.lower() in ["mae", "l1", "l1loss"]:
+            if self.loss_func.lower() in ["smoothl1", "smoothl1loss", "huber"]:
+                # keeping 'huber' for backwards compatiblility, though not identical
+                self.loss_func = torch.nn.SmoothL1Loss(reduction="none")  # , beta=0.1
+            elif self.loss_func.lower() in ["mae", "maeloss", "l1", "l1loss"]:
                 self.loss_func = torch.nn.L1Loss(reduction="none")
             elif self.loss_func.lower() in ["mse", "mseloss", "l2", "l2loss"]:
                 self.loss_func = torch.nn.MSELoss(reduction="none")

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -119,7 +119,7 @@ class Train:
         if isinstance(self.loss_func, str):
             if self.loss_func.lower() in ["smoothl1", "smoothl1loss", "huber"]:
                 # keeping 'huber' for backwards compatiblility, though not identical
-                self.loss_func = torch.nn.SmoothL1Loss(reduction="none")  # , beta=0.1
+                self.loss_func = torch.nn.SmoothL1Loss(reduction="none", beta=0.1)
             elif self.loss_func.lower() in ["mae", "maeloss", "l1", "l1loss"]:
                 self.loss_func = torch.nn.L1Loss(reduction="none")
             elif self.loss_func.lower() in ["mse", "mseloss", "l2", "l2loss"]:

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -119,7 +119,7 @@ class Train:
         if isinstance(self.loss_func, str):
             if self.loss_func.lower() in ["smoothl1", "smoothl1loss", "huber"]:
                 # keeping 'huber' for backwards compatiblility, though not identical
-                self.loss_func = torch.nn.SmoothL1Loss(reduction="none", beta=0.1)
+                self.loss_func = torch.nn.SmoothL1Loss(reduction="none", beta=0.3)
             elif self.loss_func.lower() in ["mae", "maeloss", "l1", "l1loss"]:
                 self.loss_func = torch.nn.L1Loss(reduction="none")
             elif self.loss_func.lower() in ["mse", "mseloss", "l2", "l2loss"]:

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -223,7 +223,7 @@ class NeuralProphet:
             Type of loss to use:
 
             Options
-                * (default) ``Huber``: Huber loss function
+                * (default) ``SmoothL1Loss``: SmoothL1 loss function
                 * ``MSE``: Mean Squared Error loss function
                 * ``MAE``: Mean Absolute Error loss function
                 * ``torch.nn.functional.loss.``: loss or callable for custom loss, eg. L1-Loss
@@ -360,7 +360,7 @@ class NeuralProphet:
         learning_rate: Optional[float] = None,
         epochs: Optional[int] = None,
         batch_size: Optional[int] = None,
-        loss_func: Union[str, torch.nn.modules.loss._Loss, Callable] = "Huber",
+        loss_func: Union[str, torch.nn.modules.loss._Loss, Callable] = "SmoothL1Loss",
         optimizer: Union[str, Type[torch.optim.Optimizer]] = "AdamW",
         newer_samples_weight: float = 2,
         newer_samples_start: float = 0.0,

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -9,7 +9,7 @@ def generate_config_train_params(overrides={}):
         "learning_rate": None,
         "epochs": None,
         "batch_size": None,
-        "loss_func": "Huber",
+        "loss_func": "SmoothL1Loss",
         "optimizer": "AdamW",
     }
     for key, value in overrides.items():

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -60,7 +60,7 @@ def test_uncertainty_estimation_peyton_manning():
 
     m = NeuralProphet(
         n_forecasts=1,
-        loss_func="Huber",
+        loss_func="SmoothL1Loss",
         quantiles=[0.01, 0.99],
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,


### PR DESCRIPTION
- Editing all files to mention SmoothL1Loss correctly instead of Huber loss.
- Remains backwards compatible.
- make beta of 1.0 explicit
