### PR TITLE
[WIP] On-the-fly data loading of global models

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -623,5 +623,5 @@ def _create_dataset(model, df, predict_mode, prediction_frequency=None):
         config_regressors=model.config_regressors,
         config_missing=model.config_missing,
         prediction_frequency=prediction_frequency,
-        config_train=model.config_train
+        config_train=model.config_train,
     )

--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -623,4 +623,5 @@ def _create_dataset(model, df, predict_mode, prediction_frequency=None):
         config_regressors=model.config_regressors,
         config_missing=model.config_missing,
         prediction_frequency=prediction_frequency,
+        config_train=model.config_train
     )

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1774,6 +1774,7 @@ class NeuralProphet:
                 predict_mode=True,
                 config_missing=self.config_missing,
                 prediction_frequency=self.prediction_frequency,
+                config_train=self.config_train,
             )
             loader = DataLoader(dataset, batch_size=min(4096, len(df)), shuffle=False, drop_last=False)
             predicted = {}

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2684,7 +2684,7 @@ class NeuralProphet:
                     val_dataloaders=val_loader,
                     **self.config_train.lr_finder_args,
                 )
-                # Estimate the optimat learning rate from the loss curve
+                # Estimate the optimal learning rate from the loss curve
                 assert lr_finder is not None
                 _, _, lr_suggestion = utils.smooth_loss_and_suggest(lr_finder.results)
                 self.model.learning_rate = lr_suggestion
@@ -2706,7 +2706,7 @@ class NeuralProphet:
                     **self.config_train.lr_finder_args,
                 )
                 assert lr_finder is not None
-                # Estimate the optimat learning rate from the loss curve
+                # Estimate the optimal learning rate from the loss curve
                 _, _, lr_suggestion = utils.smooth_loss_and_suggest(lr_finder.results)
                 self.model.learning_rate = lr_suggestion
             start = time.time()

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -361,6 +361,11 @@ def tabularize_univariate_datetime(
     """
     max_lags = get_max_num_lags(config_lagged_regressors, n_lags)
     n_samples = len(df) - max_lags + 1 - n_forecasts
+    #TODO
+    #n_samples = max_lags + n_forecasts
+    #if n_samples < 0:
+    #    n_samples = max_lags + n_forecasts
+
     # data is stored in OrderedDict
     inputs = OrderedDict({})
 

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -124,7 +124,19 @@ class TimeDataset(Dataset):
             return sample, targets, meta
         else:
             start_idx = index
-            end_idx = start_idx + self.kwargs.get("n_lags") + self.kwargs.get("n_forecasts")
+
+            # Lagged Regressors
+            if self.kwargs["config_lagged_regressors"]:
+                n_lagged_regressor_list = []
+                for dict_name, nested_dict in self.kwargs["config_lagged_regressors"].items():
+                    name_of_nested_dict = dict_name
+                    n_lagged_regressor = self.kwargs["config_lagged_regressors"][name_of_nested_dict].n_lags
+                    n_lagged_regressor_list.append(n_lagged_regressor)
+                max_lag = max(self.kwargs["n_lags"], *n_lagged_regressor_list)
+                end_idx = start_idx + max_lag + self.kwargs.get("n_forecasts")
+
+            else:
+                end_idx = start_idx + self.kwargs.get("n_lags") + self.kwargs.get("n_forecasts")
 
             df_slice = self.df.iloc[start_idx:end_idx]
 

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -98,7 +98,13 @@ class TimeDataset(Dataset):
         np.array, float
             Targets to be predicted of same length as each of the model inputs, dims: (num_samples, n_forecasts)
         """
-        inputs, targets, drop_missing = tabularize_univariate_datetime(self.df, **self.kwargs)
+        start_idx = index
+        #end_idx = start_idx + self.kwargs.get('n_lags') + self.kwargs.get('n_forecasts') - 1 #correct?
+        end_idx = start_idx + 1
+        df_slice = self.df.iloc[start_idx:end_idx]
+
+        # Functions
+        inputs, targets, drop_missing = tabularize_univariate_datetime(df_slice, **self.kwargs)
         self.init_after_tabularized(inputs, targets)
         self.filter_samples_after_init(self.kwargs["prediction_frequency"])
         self.drop_nan_after_init(self.df, self.kwargs["predict_steps"], drop_missing)

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -98,15 +98,16 @@ class TimeDataset(Dataset):
         np.array, float
             Targets to be predicted of same length as each of the model inputs, dims: (num_samples, n_forecasts)
         """
-        if self.kwargs['predict_mode']:
+        learning_rate = self.kwargs['config_train'].learning_rate
+        # TODO: Drop config_train from self!
+
+        if self.kwargs['predict_mode'] or (learning_rate is None):
             df_slice = self.df
         else:
             start_idx = index
-            #end_idx = start_idx + self.kwargs.get('n_lags') + self.kwargs.get('n_forecasts') - 1 #correct?
-            end_idx = start_idx + 1
+            end_idx = start_idx + self.kwargs.get('n_lags') + self.kwargs.get('n_forecasts')
+            #end_idx = start_idx + 1
             df_slice = self.df.iloc[start_idx:end_idx]
-
-        #df_slice = self.df
 
         # Functions
         inputs, targets, drop_missing = tabularize_univariate_datetime(df_slice, **self.kwargs)
@@ -291,6 +292,7 @@ def tabularize_univariate_datetime(
     config_lagged_regressors: Optional[configure.ConfigLaggedRegressors] = None,
     config_regressors: Optional[configure.ConfigFutureRegressors] = None,
     config_missing=None,
+    config_train=None,
     prediction_frequency=None,
 ):
     """Create a tabular dataset from univariate timeseries for supervised forecasting.

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -65,8 +65,15 @@ class TimeDataset(Dataset):
         ]
         self.kwargs = kwargs
 
-        learning_rate = kwargs['config_train'].learning_rate
-        if kwargs['predict_mode'] or (learning_rate is None) or kwargs['config_lagged_regressors'] or kwargs['config_country_holidays'] or kwargs['config_events'] or kwargs['prediction_frequency']:
+        learning_rate = kwargs["config_train"].learning_rate
+        if (
+            kwargs["predict_mode"]
+            or (learning_rate is None)
+            or kwargs["config_lagged_regressors"]
+            or kwargs["config_country_holidays"]
+            or kwargs["config_events"]
+            or kwargs["prediction_frequency"]
+        ):
             inputs, targets = tabularize_univariate_datetime(df, **kwargs)
             self.init_after_tabularized(inputs, targets)
             self.filter_samples_after_init(kwargs["prediction_frequency"])
@@ -102,15 +109,22 @@ class TimeDataset(Dataset):
             Targets to be predicted of same length as each of the model inputs, dims: (num_samples, n_forecasts)
         """
         # TODO: Drop config_train from self!
-        learning_rate = self.kwargs['config_train'].learning_rate
-        if self.kwargs['predict_mode'] or (learning_rate is None) or self.kwargs['config_lagged_regressors'] or self.kwargs['config_country_holidays'] or self.kwargs['config_events'] or self.kwargs['prediction_frequency']:
+        learning_rate = self.kwargs["config_train"].learning_rate
+        if (
+            self.kwargs["predict_mode"]
+            or (learning_rate is None)
+            or self.kwargs["config_lagged_regressors"]
+            or self.kwargs["config_country_holidays"]
+            or self.kwargs["config_events"]
+            or self.kwargs["prediction_frequency"]
+        ):
             sample = self.samples[index]
             targets = self.targets[index]
             meta = self.meta
             return sample, targets, meta
         else:
             start_idx = index
-            end_idx = start_idx + self.kwargs.get('n_lags') + self.kwargs.get('n_forecasts')
+            end_idx = start_idx + self.kwargs.get("n_lags") + self.kwargs.get("n_forecasts")
 
             df_slice = self.df.iloc[start_idx:end_idx]
 
@@ -138,7 +152,6 @@ class TimeDataset(Dataset):
             predict_steps : int
                 number of steps to predict
         """
-
 
     def drop_nan_after_init(self, df, predict_steps, drop_missing):
         """Checks if inputs/targets contain any NaN values and drops them, if user opts to.
@@ -361,13 +374,20 @@ def tabularize_univariate_datetime(
             Targets to be predicted of same length as each of the model inputs, dims: (num_samples, n_forecasts)
     """
     max_lags = get_max_num_lags(config_lagged_regressors, n_lags)
-    #n_samples = len(df) - max_lags + 1 - n_forecasts
-    #TODO
+    # n_samples = len(df) - max_lags + 1 - n_forecasts
+    # TODO
     learning_rate = config_train.learning_rate
-    if predict_mode or (learning_rate is None) or config_lagged_regressors or config_country_holidays or config_events or prediction_frequency:
+    if (
+        predict_mode
+        or (learning_rate is None)
+        or config_lagged_regressors
+        or config_country_holidays
+        or config_events
+        or prediction_frequency
+    ):
         n_samples = len(df) - max_lags + 1 - n_forecasts
     else:
-        n_samples=1
+        n_samples = 1
 
     # data is stored in OrderedDict
     inputs = OrderedDict({})

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -106,6 +106,8 @@ class TimeDataset(Dataset):
             end_idx = start_idx + 1
             df_slice = self.df.iloc[start_idx:end_idx]
 
+        #df_slice = self.df
+
         # Functions
         inputs, targets, drop_missing = tabularize_univariate_datetime(df_slice, **self.kwargs)
         self.init_after_tabularized(inputs, targets)

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -66,7 +66,7 @@ class TimeDataset(Dataset):
         self.kwargs = kwargs
 
         learning_rate = kwargs['config_train'].learning_rate
-        if kwargs['predict_mode'] or (learning_rate is None) or self.kwargs['config_lagged_regressors']:
+        if kwargs['predict_mode'] or (learning_rate is None) or kwargs['config_lagged_regressors'] or kwargs['config_country_holidays'] or kwargs['config_events']:
             inputs, targets = tabularize_univariate_datetime(df, **kwargs)
             self.init_after_tabularized(inputs, targets)
             self.filter_samples_after_init(kwargs["prediction_frequency"])
@@ -103,7 +103,7 @@ class TimeDataset(Dataset):
         """
         # TODO: Drop config_train from self!
         learning_rate = self.kwargs['config_train'].learning_rate
-        if self.kwargs['predict_mode'] or (learning_rate is None) or self.kwargs['config_lagged_regressors']:
+        if self.kwargs['predict_mode'] or (learning_rate is None) or self.kwargs['config_lagged_regressors'] or self.kwargs['config_country_holidays'] or self.kwargs['config_events']:
             sample = self.samples[index]
             targets = self.targets[index]
             meta = self.meta
@@ -364,7 +364,7 @@ def tabularize_univariate_datetime(
     #n_samples = len(df) - max_lags + 1 - n_forecasts
     #TODO
     learning_rate = config_train.learning_rate
-    if predict_mode or (learning_rate is None):
+    if predict_mode or (learning_rate is None) or config_lagged_regressors or config_country_holidays or config_events:
         n_samples = len(df) - max_lags + 1 - n_forecasts
     else:
         n_samples=1

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -66,7 +66,7 @@ class TimeDataset(Dataset):
         self.kwargs = kwargs
 
         learning_rate = kwargs['config_train'].learning_rate
-        if kwargs['predict_mode'] or (learning_rate is None) or kwargs['config_lagged_regressors'] or kwargs['config_country_holidays'] or kwargs['config_events']:
+        if kwargs['predict_mode'] or (learning_rate is None) or kwargs['config_lagged_regressors'] or kwargs['config_country_holidays'] or kwargs['config_events'] or kwargs['prediction_frequency']:
             inputs, targets = tabularize_univariate_datetime(df, **kwargs)
             self.init_after_tabularized(inputs, targets)
             self.filter_samples_after_init(kwargs["prediction_frequency"])
@@ -103,7 +103,7 @@ class TimeDataset(Dataset):
         """
         # TODO: Drop config_train from self!
         learning_rate = self.kwargs['config_train'].learning_rate
-        if self.kwargs['predict_mode'] or (learning_rate is None) or self.kwargs['config_lagged_regressors'] or self.kwargs['config_country_holidays'] or self.kwargs['config_events']:
+        if self.kwargs['predict_mode'] or (learning_rate is None) or self.kwargs['config_lagged_regressors'] or self.kwargs['config_country_holidays'] or self.kwargs['config_events'] or self.kwargs['prediction_frequency']:
             sample = self.samples[index]
             targets = self.targets[index]
             meta = self.meta
@@ -364,7 +364,7 @@ def tabularize_univariate_datetime(
     #n_samples = len(df) - max_lags + 1 - n_forecasts
     #TODO
     learning_rate = config_train.learning_rate
-    if predict_mode or (learning_rate is None) or config_lagged_regressors or config_country_holidays or config_events:
+    if predict_mode or (learning_rate is None) or config_lagged_regressors or config_country_holidays or config_events or prediction_frequency:
         n_samples = len(df) - max_lags + 1 - n_forecasts
     else:
         n_samples=1

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -66,7 +66,7 @@ class TimeDataset(Dataset):
         self.kwargs = kwargs
 
         learning_rate = kwargs['config_train'].learning_rate
-        if kwargs['predict_mode'] or (learning_rate is None):
+        if kwargs['predict_mode'] or (learning_rate is None) or self.kwargs['config_lagged_regressors']:
             inputs, targets = tabularize_univariate_datetime(df, **kwargs)
             self.init_after_tabularized(inputs, targets)
             self.filter_samples_after_init(kwargs["prediction_frequency"])
@@ -103,7 +103,7 @@ class TimeDataset(Dataset):
         """
         # TODO: Drop config_train from self!
         learning_rate = self.kwargs['config_train'].learning_rate
-        if self.kwargs['predict_mode'] or (learning_rate is None):
+        if self.kwargs['predict_mode'] or (learning_rate is None) or self.kwargs['config_lagged_regressors']:
             sample = self.samples[index]
             targets = self.targets[index]
             meta = self.meta
@@ -111,6 +111,7 @@ class TimeDataset(Dataset):
         else:
             start_idx = index
             end_idx = start_idx + self.kwargs.get('n_lags') + self.kwargs.get('n_forecasts')
+
             df_slice = self.df.iloc[start_idx:end_idx]
 
             # Functions
@@ -360,11 +361,13 @@ def tabularize_univariate_datetime(
             Targets to be predicted of same length as each of the model inputs, dims: (num_samples, n_forecasts)
     """
     max_lags = get_max_num_lags(config_lagged_regressors, n_lags)
-    n_samples = len(df) - max_lags + 1 - n_forecasts
+    #n_samples = len(df) - max_lags + 1 - n_forecasts
     #TODO
-    #n_samples = max_lags + n_forecasts
-    #if n_samples < 0:
-    #    n_samples = max_lags + n_forecasts
+    learning_rate = config_train.learning_rate
+    if predict_mode or (learning_rate is None):
+        n_samples = len(df) - max_lags + 1 - n_forecasts
+    else:
+        n_samples=1
 
     # data is stored in OrderedDict
     inputs = OrderedDict({})

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -106,14 +106,13 @@ class TimeDataset(Dataset):
         else:
             start_idx = index
             end_idx = start_idx + self.kwargs.get('n_lags') + self.kwargs.get('n_forecasts')
-            #end_idx = start_idx + 1
             df_slice = self.df.iloc[start_idx:end_idx]
 
         # Functions
-        inputs, targets, drop_missing = tabularize_univariate_datetime(df_slice, **self.kwargs)
+        inputs, targets = tabularize_univariate_datetime(df_slice, **self.kwargs)
         self.init_after_tabularized(inputs, targets)
         self.filter_samples_after_init(self.kwargs["prediction_frequency"])
-        self.drop_nan_after_init(self.df, self.kwargs["predict_steps"], drop_missing)
+        self.drop_nan_after_init(self.df, self.kwargs["predict_steps"], self.kwargs["config_missing"].drop_missing)
 
         sample = self.samples[index]
         targets = self.targets[index]
@@ -502,7 +501,7 @@ def tabularize_univariate_datetime(
             tabularized_input_shapes_str += f"    {key} {value.shape} \n"
     log.debug(f"Tabularized inputs shapes: \n{tabularized_input_shapes_str}")
 
-    return inputs, targets, config_missing.drop_missing
+    return inputs, targets
 
 
 def fourier_series(dates, period, series_order):

--- a/neuralprophet/time_dataset.py
+++ b/neuralprophet/time_dataset.py
@@ -98,10 +98,13 @@ class TimeDataset(Dataset):
         np.array, float
             Targets to be predicted of same length as each of the model inputs, dims: (num_samples, n_forecasts)
         """
-        start_idx = index
-        #end_idx = start_idx + self.kwargs.get('n_lags') + self.kwargs.get('n_forecasts') - 1 #correct?
-        end_idx = start_idx + 1
-        df_slice = self.df.iloc[start_idx:end_idx]
+        if self.kwargs['predict_mode']:
+            df_slice = self.df
+        else:
+            start_idx = index
+            #end_idx = start_idx + self.kwargs.get('n_lags') + self.kwargs.get('n_forecasts') - 1 #correct?
+            end_idx = start_idx + 1
+            df_slice = self.df.iloc[start_idx:end_idx]
 
         # Functions
         inputs, targets, drop_missing = tabularize_univariate_datetime(df_slice, **self.kwargs)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1712,6 +1712,7 @@ def test_on_the_fly_sampling():
     date_range = pd.date_range(start=start_date, end=end_date, freq="D")
     y = np.random.randint(0, 20, size=(len(date_range),))
     df = pd.DataFrame({"ds": date_range, "y": y})
+    df.loc[3, "y"] = np.nan
 
     m = NeuralProphet(epochs=1, learning_rate=0.01)
     m.fit(df, freq='H')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1710,9 +1710,14 @@ def test_on_the_fly_sampling():
     start_date = "2019-01-01"
     end_date = "2019-01-04"
     date_range = pd.date_range(start=start_date, end=end_date, freq="H")
-    y = np.random.randint(0, 1000, size=(len(date_range),))
-    df = pd.DataFrame({"ds": date_range, "y": y})
-
-    m = NeuralProphet(epochs=1, learning_rate=0.01)
+    #y = np.random.randint(0, 1000, size=(len(date_range),))
+    #df = pd.DataFrame({"ds": date_range, "y": y})
+    df = pd.DataFrame(
+        {
+            "ds": {0: "2022-10-16 00:00:00", 1: "2022-10-17 00:00:00", 2: "2022-10-18 00:00:00", 3: "2022-10-19 00:00:00", 4: "2022-10-20 00:00:00",},
+            "y": {0: 17, 1: 18, 2: 10, 3: 8, 4: 5},
+        }
+    )
+    m = NeuralProphet(epochs=1) #, learning_rate=0.01)
     m.fit(df, freq='H')
-    m.predict(df)
+    metrics = m.predict(df)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1706,6 +1706,7 @@ def test_unused_future_regressors():
     m.add_lagged_regressor("cost")
     m.fit(df, freq="D")
 
+
 def test_on_the_fly_sampling():
     start_date = "2022-10-16 00:00:00"
     end_date = "2022-12-30 00:00:00"
@@ -1715,5 +1716,5 @@ def test_on_the_fly_sampling():
     df.loc[3, "y"] = np.nan
 
     m = NeuralProphet(epochs=1, learning_rate=0.01)
-    m.fit(df, freq='H')
+    m.fit(df, freq="H")
     metrics = m.predict(df)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1708,7 +1708,7 @@ def test_unused_future_regressors():
 
 def test_on_the_fly_sampling():
     start_date = "2019-01-01"
-    end_date = "2019-03-01"
+    end_date = "2019-01-04"
     date_range = pd.date_range(start=start_date, end=end_date, freq="H")
     y = np.random.randint(0, 1000, size=(len(date_range),))
     df = pd.DataFrame({"ds": date_range, "y": y})

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1713,6 +1713,6 @@ def test_on_the_fly_sampling():
     y = np.random.randint(0, 1000, size=(len(date_range),))
     df = pd.DataFrame({"ds": date_range, "y": y})
 
-    m = NeuralProphet(epochs=1)
+    m = NeuralProphet(epochs=1, learning_rate=0.01)
     m.fit(df, freq='H')
     m.predict(df)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1707,17 +1707,12 @@ def test_unused_future_regressors():
     m.fit(df, freq="D")
 
 def test_on_the_fly_sampling():
-    start_date = "2019-01-01"
-    end_date = "2019-01-04"
-    date_range = pd.date_range(start=start_date, end=end_date, freq="H")
-    #y = np.random.randint(0, 1000, size=(len(date_range),))
-    #df = pd.DataFrame({"ds": date_range, "y": y})
-    df = pd.DataFrame(
-        {
-            "ds": {0: "2022-10-16 00:00:00", 1: "2022-10-17 00:00:00", 2: "2022-10-18 00:00:00", 3: "2022-10-19 00:00:00", 4: "2022-10-20 00:00:00",},
-            "y": {0: 17, 1: 18, 2: 10, 3: 8, 4: 5},
-        }
-    )
-    m = NeuralProphet(epochs=1) #, learning_rate=0.01)
+    start_date = "2022-10-16 00:00:00"
+    end_date = "2022-12-30 00:00:00"
+    date_range = pd.date_range(start=start_date, end=end_date, freq="D")
+    y = np.random.randint(0, 20, size=(len(date_range),))
+    df = pd.DataFrame({"ds": date_range, "y": y})
+
+    m = NeuralProphet(epochs=1, learning_rate=0.01)
     m.fit(df, freq='H')
     metrics = m.predict(df)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1713,7 +1713,6 @@ def test_on_the_fly_sampling():
     date_range = pd.date_range(start=start_date, end=end_date, freq="D")
     y = np.random.randint(0, 20, size=(len(date_range),))
     df = pd.DataFrame({"ds": date_range, "y": y})
-    df.loc[3, "y"] = np.nan
 
     m = NeuralProphet(epochs=1, learning_rate=0.01)
     m.fit(df, freq="H")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1717,4 +1717,4 @@ def test_on_the_fly_sampling():
 
     m = NeuralProphet(epochs=1, learning_rate=0.01)
     m.fit(df, freq="H")
-    metrics = m.predict(df)
+    _ = m.predict(df)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1705,3 +1705,14 @@ def test_unused_future_regressors():
     m.add_future_regressor("price")
     m.add_lagged_regressor("cost")
     m.fit(df, freq="D")
+
+def test_on_the_fly_sampling():
+    start_date = "2019-01-01"
+    end_date = "2019-03-01"
+    date_range = pd.date_range(start=start_date, end=end_date, freq="H")
+    y = np.random.randint(0, 1000, size=(len(date_range),))
+    df = pd.DataFrame({"ds": date_range, "y": y})
+
+    m = NeuralProphet(epochs=1)
+    m.fit(df, freq='H')
+    m.predict(df)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -82,7 +82,7 @@ def test_time_dataset():
     local_data_params, global_data_params = df_utils.init_data_params(df=df, normalize="minmax")
     df = df.drop("ID", axis=1)
     df = df_utils.normalize(df, global_data_params)
-    inputs, targets, _ = time_dataset.tabularize_univariate_datetime(
+    inputs, targets = time_dataset.tabularize_univariate_datetime(
         df, n_lags=n_lags, n_forecasts=n_forecasts, config_missing=config_missing
     )
     log.debug(
@@ -806,6 +806,13 @@ def test_too_many_NaN():
     config_missing = configure.MissingDataHandling(
         impute_missing=True, impute_linear=5, impute_rolling=5, drop_missing=False
     )
+    config_train = configure.Train(
+        learning_rate=LR,
+        epochs=EPOCHS,
+        batch_size=BATCH_SIZE,
+        loss_func="SmoothL1Loss",
+        optimizer="AdamW",
+    )
     length = 100
     days = pd.date_range(start="2017-01-01", periods=length)
     y = np.ones(length)
@@ -825,7 +832,7 @@ def test_too_many_NaN():
     df["ID"] = "__df__"
     # Check if ValueError is thrown, if NaN values remain after auto-imputing
     with pytest.raises(ValueError):
-        time_dataset.TimeDataset(df, "name", config_missing=config_missing, predict_steps=1, prediction_frequency=None)
+        time_dataset.TimeDataset(df, "name", predict_mode=False, config_missing=config_missing, config_train=config_train, predict_steps=1, prediction_frequency=None)
 
 
 def test_future_df_with_nan():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -839,7 +839,18 @@ def test_too_many_NaN():
     df["ID"] = "__df__"
     # Check if ValueError is thrown, if NaN values remain after auto-imputing
     with pytest.raises(ValueError):
-        time_dataset.TimeDataset(df, "name", predict_mode=False, config_missing=config_missing, config_lagged_regressors=None, config_country_holidays=None, config_events=None, config_train=config_train, predict_steps=1, prediction_frequency=None)
+        time_dataset.TimeDataset(
+            df,
+            "name",
+            predict_mode=False,
+            config_missing=config_missing,
+            config_lagged_regressors=None,
+            config_country_holidays=None,
+            config_events=None,
+            config_train=config_train,
+            predict_steps=1,
+            prediction_frequency=None,
+        )
 
 
 def test_future_df_with_nan():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -76,6 +76,13 @@ def test_time_dataset():
     n_forecasts = 1
     valid_p = 0.2
     config_missing = configure.MissingDataHandling()
+    config_train = configure.Train(
+        learning_rate=LR,
+        epochs=EPOCHS,
+        batch_size=BATCH_SIZE,
+        loss_func="SmoothL1Loss",
+        optimizer="AdamW",
+    )
     df_train, df_val = df_utils.split_df(df_in, n_lags, n_forecasts, valid_p)
     # create a tabularized dataset from time series
     df, _, _ = df_utils.check_dataframe(df_train)
@@ -83,7 +90,7 @@ def test_time_dataset():
     df = df.drop("ID", axis=1)
     df = df_utils.normalize(df, global_data_params)
     inputs, targets = time_dataset.tabularize_univariate_datetime(
-        df, n_lags=n_lags, n_forecasts=n_forecasts, config_missing=config_missing
+        df, n_lags=n_lags, n_forecasts=n_forecasts, config_missing=config_missing, config_train=config_train
     )
     log.debug(
         "tabularized inputs: {}".format(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -814,7 +814,7 @@ def test_too_many_NaN():
         impute_missing=True, impute_linear=5, impute_rolling=5, drop_missing=False
     )
     config_train = configure.Train(
-        learning_rate=LR,
+        learning_rate=None,
         epochs=EPOCHS,
         batch_size=BATCH_SIZE,
         loss_func="SmoothL1Loss",
@@ -839,7 +839,7 @@ def test_too_many_NaN():
     df["ID"] = "__df__"
     # Check if ValueError is thrown, if NaN values remain after auto-imputing
     with pytest.raises(ValueError):
-        time_dataset.TimeDataset(df, "name", predict_mode=False, config_missing=config_missing, config_train=config_train, predict_steps=1, prediction_frequency=None)
+        time_dataset.TimeDataset(df, "name", predict_mode=False, config_missing=config_missing, config_lagged_regressors=None, config_country_holidays=None, config_events=None, config_train=config_train, predict_steps=1, prediction_frequency=None)
 
 
 def test_future_df_with_nan():


### PR DESCRIPTION
## :microscope: Background

- Currently very high data consumption when loading global models with many IDs. Would fix https://github.com/ourownstory/neural_prophet/issues/1469

## :crystal_ball: Key changes

- On the fly sampling of the dataloader

## :clipboard: Review Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
