### PR TITLE
[fix] Plot_parameter - Yearly Seasonality

### DIFF
--- a/neuralprophet/plot_model_parameters_plotly.py
+++ b/neuralprophet/plot_model_parameters_plotly.py
@@ -502,7 +502,7 @@ def plot_yearly(m, quantile, comp_name="yearly", yearly_start=0, quick=True, mul
         )
 
     padded_range = get_dynamic_axis_range(df_y["ds"].dt.to_pydatetime(), type="dt")
-    xaxis = go.layout.XAxis(title="Day of year", range=padded_range)
+    xaxis = go.layout.XAxis(title="Day of year", range=padded_range, tickformat="%B %e",)
     yaxis = go.layout.YAxis(
         rangemode="normal",
         title=go.layout.yaxis.Title(text=f"Seasonality: {comp_name}"),

--- a/neuralprophet/plot_model_parameters_plotly.py
+++ b/neuralprophet/plot_model_parameters_plotly.py
@@ -502,7 +502,11 @@ def plot_yearly(m, quantile, comp_name="yearly", yearly_start=0, quick=True, mul
         )
 
     padded_range = get_dynamic_axis_range(df_y["ds"].dt.to_pydatetime(), type="dt")
-    xaxis = go.layout.XAxis(title="Day of year", range=padded_range, tickformat="%B %e",)
+    xaxis = go.layout.XAxis(
+        title="Day of year",
+        range=padded_range,
+        tickformat="%B %e",
+    )
     yaxis = go.layout.YAxis(
         rangemode="normal",
         title=go.layout.yaxis.Title(text=f"Seasonality: {comp_name}"),


### PR DESCRIPTION
## :microscope: Background

- When plotting the yearly seasonality component with model.plot_parameters(), the year is shown on the xaxis.
- Solves #1500 
- Only occurs using plotly 
- Issue does not occur with daily or weekly seasonalities

## :crystal_ball: Key changes

- Adjusted x-axis tick labels in plot_yearly

## :clipboard: Review Checklist
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, added docstrings and data types to function definitions.
- [X] I have added pytests to check whether my feature / fix works.