### PR TITLE
[Major] Combined future regressor layer arguments into one single integer list `regressors_layers` like `ar_layers`

### DIFF
--- a/neuralprophet/components/future_regressors/neural_nets.py
+++ b/neuralprophet/components/future_regressors/neural_nets.py
@@ -21,18 +21,16 @@ class NeuralNetsFutureRegressors(FutureRegressors):
         if self.regressors_dims is not None:
             # Regresors params
             self.regressor_nets = nn.ModuleDict({})
-            # TO DO: if no hidden layers, then just a as legacy
-            self.d_hidden_regressors = config.d_hidden
-            self.num_hidden_layers_regressors = config.num_hidden_layers
+            self.regressors_layers = config.regressors_layers
             # one net per regressor. to be adapted to combined network
             for regressor in self.regressors_dims.keys():
                 # Nets for both additive and multiplicative regressors
                 regressor_net = nn.ModuleList()
                 # This will be later 1 + static covariates
                 d_inputs = 1
-                for i in range(self.num_hidden_layers_regressors):
-                    regressor_net.append(nn.Linear(d_inputs, self.d_hidden_regressors, bias=True))
-                    d_inputs = self.d_hidden_regressors
+                for d_hidden_i in self.regressors_layers:
+                    regressor_net.append(nn.Linear(d_inputs, d_hidden_i, bias=True))
+                    d_inputs = d_hidden_i
                 # final layer has input size d_inputs and output size equal to no. of quantiles
                 regressor_net.append(nn.Linear(d_inputs, len(self.quantiles), bias=False))
                 for lay in regressor_net:
@@ -79,7 +77,7 @@ class NeuralNetsFutureRegressors(FutureRegressors):
                 Forecast component of dims (batch, n_forecasts, num_quantiles)
         """
         x = regressor_input
-        for i in range(self.num_hidden_layers_regressors + 1):
+        for i in range(len(self.regressors_layers) + 1):
             if i > 0:
                 x = nn.functional.relu(x)
             x = self.regressor_nets[name][i](x)

--- a/neuralprophet/components/future_regressors/shared_neural_nets.py
+++ b/neuralprophet/components/future_regressors/shared_neural_nets.py
@@ -21,18 +21,16 @@ class SharedNeuralNetsFutureRegressors(FutureRegressors):
         if self.regressors_dims is not None:
             # Regresors params
             self.regressor_nets = nn.ModuleDict({})
-            # TO DO: if no hidden layers, then just a as legacy
-            self.d_hidden_regressors = config.d_hidden
-            self.num_hidden_layers_regressors = config.num_hidden_layers
+            self.regressors_layers = config.regressors_layers
             # Combined network
             for net_i, size_i in Counter([x["mode"] for x in self.regressors_dims.values()]).items():
                 # Nets for both additive and multiplicative regressors
                 regressor_net = nn.ModuleList()
                 # This will be later size_i(1 + static covariates)
                 d_inputs = size_i
-                for i in range(self.num_hidden_layers_regressors):
-                    regressor_net.append(nn.Linear(d_inputs, self.d_hidden_regressors, bias=True))
-                    d_inputs = self.d_hidden_regressors
+                for d_hidden_i in self.regressors_layers:
+                    regressor_net.append(nn.Linear(d_inputs, d_hidden_i, bias=True))
+                    d_inputs = d_hidden_i
                 # final layer has input size d_inputs and output size equal to  no. of quantiles
                 regressor_net.append(nn.Linear(d_inputs, len(self.quantiles), bias=False))
                 for lay in regressor_net:
@@ -81,7 +79,7 @@ class SharedNeuralNetsFutureRegressors(FutureRegressors):
                 Forecast component of dims (batch, n_forecasts, num_quantiles)
         """
         x = regressor_inputs
-        for i in range(self.num_hidden_layers_regressors + 1):
+        for i in range(len(self.regressors_layers) + 1):
             if i > 0:
                 x = nn.functional.relu(x)
             x = self.regressor_nets[mode][i](x)

--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -478,8 +478,8 @@ class Regressor:
 @dataclass
 class ConfigFutureRegressors:
     model: str
-    d_hidden: int
-    num_hidden_layers: int
+    regressors_layers: Optional[List[int]]
+
     regressors: OrderedDict = field(init=False)  # contains RegressorConfig objects
 
     def __post_init__(self):

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -199,13 +199,10 @@ class NeuralProphet:
                 * ``shared_neural_nets``
                 * ``shared_neural_nets_coef``
 
-        future_regressors_d_hidden: int
-            Number of hidden layers in the neural network model for future regressors.
-            Ignored if ``future_regressors_model`` is ``linear``.
+        future_regressors_layers: list of int
+            array of hidden layer dimensions of the future regressor nets. Specifies number of hidden layers (number of entries)
+            and layer dimension (list entry).
 
-        future_regressors_num_hidden_layers: int
-            Dimension of hidden layers in the neural network model for future regressors.
-            Ignored if ``future_regressors_model`` is ``linear``.
 
         COMMENT
         AR Config
@@ -424,8 +421,7 @@ class NeuralProphet:
         season_global_local: np_types.SeasonGlobalLocalMode = "global",
         seasonality_local_reg: Optional[Union[bool, float]] = False,
         future_regressors_model: np_types.FutureRegressorsModel = "linear",
-        future_regressors_d_hidden: int = 4,
-        future_regressors_num_hidden_layers: int = 2,
+        future_regressors_layers: Optional[list] = [4,4],
         n_forecasts: int = 1,
         n_lags: int = 0,
         ar_layers: Optional[list] = [],
@@ -541,8 +537,7 @@ class NeuralProphet:
         self.config_lagged_regressors: Optional[configure.ConfigLaggedRegressors] = None
         self.config_regressors = configure.ConfigFutureRegressors(
             model=future_regressors_model,
-            d_hidden=future_regressors_d_hidden,
-            num_hidden_layers=future_regressors_num_hidden_layers,
+            regressors_layers=future_regressors_layers,
         )  # Optional[configure.ConfigFutureRegressors] = None
 
         # set during fit()

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -200,8 +200,8 @@ class NeuralProphet:
                 * ``shared_neural_nets_coef``
 
         future_regressors_layers: list of int
-            array of hidden layer dimensions of the future regressor nets. Specifies number of hidden layers (number of entries)
-            and layer dimension (list entry).
+            list of hidden layer dimensions of the future regressor nets. Specifies number of hidden layers (number of entries)
+            and layer dimension (list entry). Default [] (no hidden layers)
 
 
         COMMENT
@@ -421,7 +421,7 @@ class NeuralProphet:
         season_global_local: np_types.SeasonGlobalLocalMode = "global",
         seasonality_local_reg: Optional[Union[bool, float]] = False,
         future_regressors_model: np_types.FutureRegressorsModel = "linear",
-        future_regressors_layers: Optional[list] = [4, 4],
+        future_regressors_layers: Optional[list] = [],
         n_forecasts: int = 1,
         n_lags: int = 0,
         ar_layers: Optional[list] = [],

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -421,7 +421,7 @@ class NeuralProphet:
         season_global_local: np_types.SeasonGlobalLocalMode = "global",
         seasonality_local_reg: Optional[Union[bool, float]] = False,
         future_regressors_model: np_types.FutureRegressorsModel = "linear",
-        future_regressors_layers: Optional[list] = [4,4],
+        future_regressors_layers: Optional[list] = [4, 4],
         n_forecasts: int = 1,
         n_lags: int = 0,
         ar_layers: Optional[list] = [],

--- a/tests/test_future_regressor_nn.py
+++ b/tests/test_future_regressor_nn.py
@@ -124,8 +124,7 @@ def test_future_regressor_nn_2():
         weekly_seasonality=False,
         daily_seasonality=True,
         future_regressors_model="neural_nets",  # 'linear' default or 'neural_nets'
-        future_regressors_d_hidden=4,  # (int)
-        future_regressors_num_hidden_layers=2,  # (int)
+        future_regressors_layers=[4, 4],
         n_forecasts=3,
         n_lags=5,
         drop_missing=True,
@@ -161,8 +160,7 @@ def test_future_regressor_nn_shared_2():
         weekly_seasonality=False,
         daily_seasonality=True,
         future_regressors_model="shared_neural_nets",
-        future_regressors_d_hidden=4,
-        future_regressors_num_hidden_layers=2,
+        future_regressors_layers=[4, 4],
         n_forecasts=3,
         n_lags=5,
         drop_missing=True,
@@ -187,8 +185,7 @@ def test_future_regressor_nn_shared_2():
 #         weekly_seasonality=False,
 #         daily_seasonality=True,
 #         future_regressors_model="shared_neural_nets_coef",
-#         future_regressors_d_hidden=4,
-#         future_regressors_num_hidden_layers=2,
+#         future_regressors_layers=[4, 4],
 #         n_forecasts=3,
 #         n_lags=5,
 #         drop_missing=True,


### PR DESCRIPTION
## :microscope: Background

- fixes issue #1375 

## :crystal_ball: Key changes

Removed the arguments `future_regressors_num_hidden_layers` and `future_regressors_d_hidden` and replaced them with a single argument `future_regressors_layers : Optional[List[int]]`. (following the practice of `ar_layers`)
- length holds the number of hidden layers
- values hold the dimension of each layer

## :clipboard: Review Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, added docstrings and data types to function definitions.
- [x] I have added pytests to check whether my feature / fix works.
