### PR TITLE
[Major] simplify learning rate finder and use log-mean of default and smooth suggestion

### DIFF
--- a/neuralprophet/configure.py
+++ b/neuralprophet/configure.py
@@ -208,7 +208,7 @@ class Train:
         Set the lr_finder_args.
         This is the range of learning rates to test.
         """
-        num_training = 150 + int(np.log10(100 + dataset_size) * 25)
+        num_training = 100 + int(np.log10(dataset_size) * 20)
         if num_batches < num_training:
             log.warning(
                 f"Learning rate finder: The number of batches ({num_batches}) is too small than the required number \
@@ -217,7 +217,7 @@ class Train:
             # num_training = num_batches
         self.lr_finder_args.update(
             {
-                "min_lr": 1e-6,
+                "min_lr": 1e-7,
                 "max_lr": 10,
                 "num_training": num_training,
                 "early_stop_threshold": None,

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2805,7 +2805,7 @@ class NeuralProphet:
                 lr_finder = tuner.lr_find(
                     model=self.model,
                     train_dataloaders=train_loader,
-                    val_dataloaders=val_loader,
+                    # val_dataloaders=val_loader, # not be used, but may lead to Lightning bug if not provided
                     **self.config_train.lr_finder_args,
                 )
                 # Estimate the optimal learning rate from the loss curve

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -772,7 +772,8 @@ def smooth_loss_and_suggest(lr_finder_results, window=10):
     lr = lr_finder_results["lr"]
     loss = lr_finder_results["loss"]
     # Derive window size from num lr searches, ensure window is divisible by 2
-    half_window = math.ceil(round(len(loss) * 0.1) / 2)
+    # half_window = math.ceil(round(len(loss) * 0.1) / 2)
+    half_window = math.ceil(window / 2)
     # Pad sequence and initialialize hamming filter
     loss = np.pad(np.array(loss), pad_width=half_window, mode="edge")
     window = np.hamming(half_window * 2)


### PR DESCRIPTION
The LR finder implementation had changed with the transition to using the Lightning implementation. This PR simplifies that implementation and additionally uses the logarithmic mean value of our smooth and the default version.
