### PR TITLE
Update CI metrics.yml to use Node 20 

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       
-      - name: Install Python 3.11
+      - name: Install Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       
       - name: Setup NodeJS (for CML)
         uses: actions/setup-node@v3 # For CML

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -21,15 +21,15 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       
-      - name: Install Python 3.12
+      - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       
       - name: Setup NodeJS (for CML)
         uses: actions/setup-node@v3 # For CML
         with:
-          node-version: '16'
+          node-version: '20'
       
       - name: Setup CML
         uses: iterative/setup-cml@v1


### PR DESCRIPTION
Addressing [Warning](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)