### PR TITLE
np.NaN -> np.nan (Error)

### DIFF
--- a/neuralprophet/data/process.py
+++ b/neuralprophet/data/process.py
@@ -69,7 +69,7 @@ def _reshape_raw_predictions_to_forecst_df(
             forecast = predicted[:, forecast_lag - 1, j]
             pad_before = max_lags + forecast_lag - 1
             pad_after = n_forecasts - forecast_lag
-            yhat = np.pad(forecast, (pad_before, pad_after), mode="constant", constant_values=np.NaN)
+            yhat = np.pad(forecast, (pad_before, pad_after), mode="constant", constant_values=np.nan)
             if prediction_frequency is not None:
                 ds = df_forecast["ds"].iloc[pad_before : -pad_after if pad_after > 0 else None]
                 mask = df_utils.create_mask_for_prediction_frequency(
@@ -79,7 +79,7 @@ def _reshape_raw_predictions_to_forecst_df(
                 )
                 yhat = np.full((len(ds),), np.nan)
                 yhat[mask] = forecast
-                yhat = np.pad(yhat, (pad_before, pad_after), mode="constant", constant_values=np.NaN)
+                yhat = np.pad(yhat, (pad_before, pad_after), mode="constant", constant_values=np.nan)
             # 0 is the median quantile index
             if j == 0:
                 name = f"yhat{forecast_lag}"
@@ -104,7 +104,7 @@ def _reshape_raw_predictions_to_forecst_df(
                     forecast = components[comp][:, forecast_lag - 1, j]  # 0 is the median quantile
                     pad_before = max_lags + forecast_lag - 1
                     pad_after = n_forecasts - forecast_lag
-                    yhat = np.pad(forecast, (pad_before, pad_after), mode="constant", constant_values=np.NaN)
+                    yhat = np.pad(forecast, (pad_before, pad_after), mode="constant", constant_values=np.nan)
                     if prediction_frequency is not None:
                         ds = df_forecast["ds"].iloc[pad_before : -pad_after if pad_after > 0 else None]
                         mask = df_utils.create_mask_for_prediction_frequency(
@@ -114,7 +114,7 @@ def _reshape_raw_predictions_to_forecst_df(
                         )
                         yhat = np.full((len(ds),), np.nan)
                         yhat[mask] = forecast
-                        yhat = np.pad(yhat, (pad_before, pad_after), mode="constant", constant_values=np.NaN)
+                        yhat = np.pad(yhat, (pad_before, pad_after), mode="constant", constant_values=np.nan)
                     if j == 0:  # temporary condition to add only the median component
                         name = f"{comp}{forecast_lag}"
                         df_forecast[name] = yhat
@@ -126,7 +126,7 @@ def _reshape_raw_predictions_to_forecst_df(
                 forecast_0 = components[comp][0, :, j]
                 forecast_rest = components[comp][1:, n_forecasts - 1, j]
                 yhat = np.pad(
-                    np.concatenate((forecast_0, forecast_rest)), (max_lags, 0), mode="constant", constant_values=np.NaN
+                    np.concatenate((forecast_0, forecast_rest)), (max_lags, 0), mode="constant", constant_values=np.nan
                 )
                 if prediction_frequency is not None:
                     date_list = []

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -1117,7 +1117,7 @@ def get_freq_dist(ds_col):
         tuple
             numeric delta values (``ms``) and distribution of frequency counts
     """
-    converted_ds = pd.to_datetime(ds_col, utc=True).view(dtype=np.int64)
+    converted_ds = pd.to_datetime(ds_col, utc=True).astype(dtype=np.int64)
     diff_ds = np.unique(converted_ds.diff(), return_counts=True)
     return diff_ds
 


### PR DESCRIPTION
np.NaN -> np.nan (Error)
view(dtype) -> astype(dtype) (Warning)

## :microscope: Background

- Numpy obsoleted use of `np.NaN` in favor of `np.nan`
- Pandas deprecated use of `view()` in favor of astype()

## :crystal_ball: Key changes

- Eliminated runtime errors and warnings by following dependency package maintainer's suggestions

## :clipboard: Review Checklist
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, added docstrings and data types to function definitions.
- [ ] I have added pytests to check whether my feature / fix works.

Please make sure to follow our best practices in the [Contributing guidelines](https://github.com/ourownstory/neural_prophet/blob/main/CONTRIBUTING.md).
